### PR TITLE
Remove format type from function names

### DIFF
--- a/c_bindings/include/crunch64/yay0.h
+++ b/c_bindings/include/crunch64/yay0.h
@@ -26,13 +26,13 @@ extern "C"
  * @param src_len Size of `src`
  * @param src[in] Compressed Yay0 data
  */
-Crunch64Error crunch64_decompress_yay0_bound(size_t *dst_size, size_t src_len, const uint8_t *const src);
+Crunch64Error crunch64_yay0_decompress_bound(size_t *dst_size, size_t src_len, const uint8_t *const src);
 
 /**
  * @brief Decompresses the data pointed by `src` and puts that data into `dst`.
  *
  * The `dst` should point to a buffer big enough to hold the decompressed data. To know how big said buffer must be
- * refer to `crunch64_decompress_yay0_bound`.
+ * refer to `crunch64_yay0_decompress_bound`.
  *
  * When this function is called, `dst_len` must point to the size of the `dst` pointer, allowing for range checking
  * and avoiding to write out of bounds.
@@ -47,7 +47,7 @@ Crunch64Error crunch64_decompress_yay0_bound(size_t *dst_size, size_t src_len, c
  * @param src_len The length of the data pointed by `src`.
  * @param src[in] Pointer to compressed data. Must contain the Yay0 header.
  */
-Crunch64Error crunch64_decompress_yay0(size_t *dst_len, uint8_t *dst, size_t src_len, const uint8_t *const src);
+Crunch64Error crunch64_yay0_decompress(size_t *dst_len, uint8_t *dst, size_t src_len, const uint8_t *const src);
 
 /**
  * @brief Get a size big enough to allocate a buffer that can fit the compressed data produced by compressing `src`.
@@ -62,13 +62,13 @@ Crunch64Error crunch64_decompress_yay0(size_t *dst_len, uint8_t *dst, size_t src
  * @param src_len Size of `src`
  * @param src[in] Data that would be compressed
  */
-Crunch64Error crunch64_compress_yay0_bound(size_t *dst_size, size_t src_len, const uint8_t *const src);
+Crunch64Error crunch64_yay0_compress_bound(size_t *dst_size, size_t src_len, const uint8_t *const src);
 
 /**
  * @brief Compresses the data pointed by `src` and puts that data into `dst`.
  *
  * The `dst` should point to a buffer big enough to hold the compressed data. To know how big said buffer must be
- * refer to `crunch64_compress_yay0_bound`.
+ * refer to `crunch64_yay0_compress_bound`.
  *
  * When this function is called, `dst_len` must point to the size of the `dst` pointer, allowing for range checking
  * and avoiding to write out of bounds.
@@ -85,7 +85,7 @@ Crunch64Error crunch64_compress_yay0_bound(size_t *dst_size, size_t src_len, con
  * @param src_len The length of the data pointed by `src`.
  * @param src[in] Pointer to the decompressed data.
  */
-Crunch64Error crunch64_compress_yay0(size_t *dst_len, uint8_t *dst, size_t src_len, const uint8_t *const src);
+Crunch64Error crunch64_yay0_compress(size_t *dst_len, uint8_t *dst, size_t src_len, const uint8_t *const src);
 
 #ifdef __cplusplus
 }

--- a/c_bindings/include/crunch64/yaz0.h
+++ b/c_bindings/include/crunch64/yaz0.h
@@ -26,13 +26,13 @@ extern "C"
  * @param src_len Size of `src`
  * @param src[in] Compressed Yaz0 data
  */
-Crunch64Error crunch64_decompress_yaz0_bound(size_t *dst_size, size_t src_len, const uint8_t *const src);
+Crunch64Error crunch64_yaz0_decompress_bound(size_t *dst_size, size_t src_len, const uint8_t *const src);
 
 /**
  * @brief Decompresses the data pointed by `src` and puts that data into `dst`.
  *
  * The `dst` should point to a buffer big enough to hold the decompressed data. To know how big said buffer must be
- * refer to `crunch64_decompress_yaz0_bound`.
+ * refer to `crunch64_yaz0_decompress_bound`.
  *
  * When this function is called, `dst_len` must point to the size of the `dst` pointer, allowing for range checking
  * and avoiding to write out of bounds.
@@ -47,7 +47,7 @@ Crunch64Error crunch64_decompress_yaz0_bound(size_t *dst_size, size_t src_len, c
  * @param src_len The length of the data pointed by `src`.
  * @param src[in] Pointer to compressed data. Must contain the Yaz0 header.
  */
-Crunch64Error crunch64_decompress_yaz0(size_t *dst_len, uint8_t *dst, size_t src_len, const uint8_t *const src);
+Crunch64Error crunch64_yaz0_decompress(size_t *dst_len, uint8_t *dst, size_t src_len, const uint8_t *const src);
 
 /**
  * @brief Get a size big enough to allocate a buffer that can fit the compressed data produced by compressing `src`.
@@ -62,13 +62,13 @@ Crunch64Error crunch64_decompress_yaz0(size_t *dst_len, uint8_t *dst, size_t src
  * @param src_len Size of `src`
  * @param src[in] Data that would be compressed
  */
-Crunch64Error crunch64_compress_yaz0_bound(size_t *dst_size, size_t src_len, const uint8_t *const src);
+Crunch64Error crunch64_yaz0_compress_bound(size_t *dst_size, size_t src_len, const uint8_t *const src);
 
 /**
  * @brief Compresses the data pointed by `src` and puts that data into `dst`.
  *
  * The `dst` should point to a buffer big enough to hold the compressed data. To know how big said buffer must be
- * refer to `crunch64_compress_yaz0_bound`.
+ * refer to `crunch64_yaz0_compress_bound`.
  *
  * When this function is called, `dst_len` must point to the size of the `dst` pointer, allowing for range checking
  * and avoiding to write out of bounds.
@@ -85,7 +85,7 @@ Crunch64Error crunch64_compress_yaz0_bound(size_t *dst_size, size_t src_len, con
  * @param src_len The length of the data pointed by `src`.
  * @param src[in] Pointer to the decompressed data.
  */
-Crunch64Error crunch64_compress_yaz0(size_t *dst_len, uint8_t *dst, size_t src_len, const uint8_t *const src);
+Crunch64Error crunch64_yaz0_compress(size_t *dst_len, uint8_t *dst, size_t src_len, const uint8_t *const src);
 
 #ifdef __cplusplus
 }

--- a/c_bindings/tests/test_yay0.c
+++ b/c_bindings/tests/test_yay0.c
@@ -11,7 +11,7 @@ bool decompress(size_t *dst_size, uint8_t **dst, size_t src_size, const uint8_t 
     size_t decompressed_size;
     uint8_t *decompressed_data = NULL;
 
-    Crunch64Error size_request_ok = crunch64_decompress_yay0_bound(&decompressed_size, src_size, src);
+    Crunch64Error size_request_ok = crunch64_yay0_decompress_bound(&decompressed_size, src_size, src);
     if (size_request_ok != Crunch64Error_Okay)
     {
         fprintf(stderr, " failed to request size for buffer. Reason: %s\n", get_crunch64_error_str(size_request_ok));
@@ -25,7 +25,7 @@ bool decompress(size_t *dst_size, uint8_t **dst, size_t src_size, const uint8_t 
         return false;
     }
 
-    Crunch64Error decompress_ok = crunch64_decompress_yay0(&decompressed_size, decompressed_data, src_size, src);
+    Crunch64Error decompress_ok = crunch64_yay0_decompress(&decompressed_size, decompressed_data, src_size, src);
     if (decompress_ok != Crunch64Error_Okay)
     {
         fprintf(stderr, " failed to decompress data. Reason: %s\n", get_crunch64_error_str(decompress_ok));
@@ -49,7 +49,7 @@ bool compress(size_t *dst_size, uint8_t **dst, size_t src_size, const uint8_t *s
     assert(dst != NULL);
     assert(src != NULL);
 
-    Crunch64Error size_request_ok = crunch64_compress_yay0_bound(&compressed_size, src_size, src);
+    Crunch64Error size_request_ok = crunch64_yay0_compress_bound(&compressed_size, src_size, src);
     if (size_request_ok != Crunch64Error_Okay)
     {
         fprintf(stderr, " failed to request size for buffer. Reason: %s\n", get_crunch64_error_str(size_request_ok));
@@ -63,7 +63,7 @@ bool compress(size_t *dst_size, uint8_t **dst, size_t src_size, const uint8_t *s
         return false;
     }
 
-    Crunch64Error compress_ok = crunch64_compress_yay0(&compressed_size, compressed_data, src_size, src);
+    Crunch64Error compress_ok = crunch64_yay0_compress(&compressed_size, compressed_data, src_size, src);
     if (compress_ok != Crunch64Error_Okay)
     {
         fprintf(stderr, " failed to decompress data. Reason: %s\n", get_crunch64_error_str(compress_ok));

--- a/c_bindings/tests/test_yaz0.c
+++ b/c_bindings/tests/test_yaz0.c
@@ -11,7 +11,7 @@ bool decompress(size_t *dst_size, uint8_t **dst, size_t src_size, const uint8_t 
     size_t decompressed_size;
     uint8_t *decompressed_data = NULL;
 
-    Crunch64Error size_request_ok = crunch64_decompress_yaz0_bound(&decompressed_size, src_size, src);
+    Crunch64Error size_request_ok = crunch64_yaz0_decompress_bound(&decompressed_size, src_size, src);
     if (size_request_ok != Crunch64Error_Okay)
     {
         fprintf(stderr, " failed to request size for buffer. Reason: %s\n", get_crunch64_error_str(size_request_ok));
@@ -25,7 +25,7 @@ bool decompress(size_t *dst_size, uint8_t **dst, size_t src_size, const uint8_t 
         return false;
     }
 
-    Crunch64Error decompress_ok = crunch64_decompress_yaz0(&decompressed_size, decompressed_data, src_size, src);
+    Crunch64Error decompress_ok = crunch64_yaz0_decompress(&decompressed_size, decompressed_data, src_size, src);
     if (decompress_ok != Crunch64Error_Okay)
     {
         fprintf(stderr, " failed to decompress data. Reason: %s\n", get_crunch64_error_str(decompress_ok));
@@ -49,7 +49,7 @@ bool compress(size_t *dst_size, uint8_t **dst, size_t src_size, const uint8_t *s
     assert(dst != NULL);
     assert(src != NULL);
 
-    Crunch64Error size_request_ok = crunch64_compress_yaz0_bound(&compressed_size, src_size, src);
+    Crunch64Error size_request_ok = crunch64_yaz0_compress_bound(&compressed_size, src_size, src);
     if (size_request_ok != Crunch64Error_Okay)
     {
         fprintf(stderr, " failed to request size for buffer. Reason: %s\n", get_crunch64_error_str(size_request_ok));
@@ -63,7 +63,7 @@ bool compress(size_t *dst_size, uint8_t **dst, size_t src_size, const uint8_t *s
         return false;
     }
 
-    Crunch64Error compress_ok = crunch64_compress_yaz0(&compressed_size, compressed_data, src_size, src);
+    Crunch64Error compress_ok = crunch64_yaz0_compress(&compressed_size, compressed_data, src_size, src);
     if (compress_ok != Crunch64Error_Okay)
     {
         fprintf(stderr, " failed to decompress data. Reason: %s\n", get_crunch64_error_str(compress_ok));

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -4,8 +4,8 @@ pub mod yaz0;
 mod utils;
 
 use thiserror::Error;
-use yay0::{compress_yay0, decompress_yay0};
-use yaz0::{compress_yaz0, decompress_yaz0};
+use yay0::{yay0_compress, yay0_decompress};
+use yaz0::{yaz0_compress, yaz0_decompress};
 
 /* This needs to be in sync with the C equivalent at `crunch64_error.h` */
 #[cfg_attr(feature = "c_bindings", repr(u32))]
@@ -42,16 +42,16 @@ pub enum CompressionType {
 impl CompressionType {
     pub fn decompress(self: CompressionType, bytes: &[u8]) -> Result<Box<[u8]>, Crunch64Error> {
         match self {
-            CompressionType::Yay0 => decompress_yay0(bytes),
-            CompressionType::Yaz0 => decompress_yaz0(bytes),
+            CompressionType::Yay0 => yay0_decompress(bytes),
+            CompressionType::Yaz0 => yaz0_decompress(bytes),
             _ => Err(Crunch64Error::UnsupportedCompressionType),
         }
     }
 
     pub fn compress(self: CompressionType, bytes: &[u8]) -> Result<Box<[u8]>, Crunch64Error> {
         match self {
-            CompressionType::Yay0 => compress_yay0(bytes),
-            CompressionType::Yaz0 => compress_yaz0(bytes),
+            CompressionType::Yay0 => yay0_compress(bytes),
+            CompressionType::Yaz0 => yaz0_compress(bytes),
             _ => Err(Crunch64Error::UnsupportedCompressionType),
         }
     }

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -4,8 +4,6 @@ pub mod yaz0;
 mod utils;
 
 use thiserror::Error;
-use yay0::{yay0_compress, yay0_decompress};
-use yaz0::{yaz0_compress, yaz0_decompress};
 
 /* This needs to be in sync with the C equivalent at `crunch64_error.h` */
 #[cfg_attr(feature = "c_bindings", repr(u32))]
@@ -42,16 +40,16 @@ pub enum CompressionType {
 impl CompressionType {
     pub fn decompress(self: CompressionType, bytes: &[u8]) -> Result<Box<[u8]>, Crunch64Error> {
         match self {
-            CompressionType::Yay0 => yay0_decompress(bytes),
-            CompressionType::Yaz0 => yaz0_decompress(bytes),
+            CompressionType::Yay0 => yay0::decompress(bytes),
+            CompressionType::Yaz0 => yaz0::decompress(bytes),
             _ => Err(Crunch64Error::UnsupportedCompressionType),
         }
     }
 
     pub fn compress(self: CompressionType, bytes: &[u8]) -> Result<Box<[u8]>, Crunch64Error> {
         match self {
-            CompressionType::Yay0 => yay0_compress(bytes),
-            CompressionType::Yaz0 => yaz0_compress(bytes),
+            CompressionType::Yay0 => yay0::compress(bytes),
+            CompressionType::Yaz0 => yaz0::compress(bytes),
             _ => Err(Crunch64Error::UnsupportedCompressionType),
         }
     }

--- a/lib/src/yay0.rs
+++ b/lib/src/yay0.rs
@@ -30,7 +30,7 @@ fn write_header(
     Ok(())
 }
 
-pub fn yay0_decompress(bytes: &[u8]) -> Result<Box<[u8]>, Crunch64Error> {
+pub fn decompress(bytes: &[u8]) -> Result<Box<[u8]>, Crunch64Error> {
     let (decompressed_size, link_table_offset, chunk_offset) = parse_header(bytes)?;
 
     let mut link_table_idx = link_table_offset;
@@ -94,7 +94,7 @@ fn size_for_compressed_buffer(input_size: usize) -> Result<usize, Crunch64Error>
     Ok(input_size + divide_round_up(input_size, 8) + 0x10)
 }
 
-pub fn yay0_compress(bytes: &[u8]) -> Result<Box<[u8]>, Crunch64Error> {
+pub fn compress(bytes: &[u8]) -> Result<Box<[u8]>, Crunch64Error> {
     let input_size = bytes.len();
 
     let mut pp: usize = 0;
@@ -254,7 +254,7 @@ mod c_bindings {
             Ok(d) => d,
         };
 
-        let data = match super::yay0_decompress(&bytes) {
+        let data = match super::decompress(&bytes) {
             Err(e) => return e,
             Ok(d) => d,
         };
@@ -300,7 +300,7 @@ mod c_bindings {
             Ok(d) => d,
         };
 
-        let data = match super::yay0_compress(&bytes) {
+        let data = match super::compress(&bytes) {
             Err(e) => return e,
             Ok(d) => d,
         };
@@ -347,7 +347,7 @@ mod tests {
         let compressed_file = &read_test_file(path.clone());
         let decompressed_file = &read_test_file(path.with_extension(""));
 
-        let decompressed = super::yay0_decompress(compressed_file)?;
+        let decompressed = super::decompress(compressed_file)?;
         assert_eq!(decompressed_file, decompressed.as_ref());
         Ok(())
     }
@@ -359,7 +359,7 @@ mod tests {
         let compressed_file = &read_test_file(path.clone());
         let decompressed_file = &read_test_file(path.with_extension(""));
 
-        let compressed = super::yay0_compress(decompressed_file.as_slice())?;
+        let compressed = super::compress(decompressed_file.as_slice())?;
         assert_eq!(compressed_file, compressed.as_ref());
         Ok(())
     }
@@ -372,7 +372,7 @@ mod tests {
 
         assert_eq!(
             decompressed_file,
-            super::yay0_decompress(&super::yay0_compress(decompressed_file.as_ref())?)?.as_ref()
+            super::decompress(&super::compress(decompressed_file.as_ref())?)?.as_ref()
         );
         Ok(())
     }
@@ -385,7 +385,7 @@ mod tests {
 
         assert_eq!(
             compressed_file,
-            super::yay0_compress(&super::yay0_decompress(compressed_file.as_ref())?)?.as_ref()
+            super::compress(&super::decompress(compressed_file.as_ref())?)?.as_ref()
         );
         Ok(())
     }

--- a/lib/src/yay0.rs
+++ b/lib/src/yay0.rs
@@ -30,7 +30,7 @@ fn write_header(
     Ok(())
 }
 
-pub fn decompress_yay0(bytes: &[u8]) -> Result<Box<[u8]>, Crunch64Error> {
+pub fn yay0_decompress(bytes: &[u8]) -> Result<Box<[u8]>, Crunch64Error> {
     let (decompressed_size, link_table_offset, chunk_offset) = parse_header(bytes)?;
 
     let mut link_table_idx = link_table_offset;
@@ -94,7 +94,7 @@ fn size_for_compressed_buffer(input_size: usize) -> Result<usize, Crunch64Error>
     Ok(input_size + divide_round_up(input_size, 8) + 0x10)
 }
 
-pub fn compress_yay0(bytes: &[u8]) -> Result<Box<[u8]>, Crunch64Error> {
+pub fn yay0_compress(bytes: &[u8]) -> Result<Box<[u8]>, Crunch64Error> {
     let input_size = bytes.len();
 
     let mut pp: usize = 0;
@@ -212,7 +212,7 @@ pub fn compress_yay0(bytes: &[u8]) -> Result<Box<[u8]>, Crunch64Error> {
 #[cfg(feature = "c_bindings")]
 mod c_bindings {
     #[no_mangle]
-    pub extern "C" fn crunch64_decompress_yay0_bound(
+    pub extern "C" fn crunch64_yay0_decompress_bound(
         dst_size: *mut usize,
         src_len: usize,
         src: *const u8,
@@ -239,7 +239,7 @@ mod c_bindings {
     }
 
     #[no_mangle]
-    pub extern "C" fn crunch64_decompress_yay0(
+    pub extern "C" fn crunch64_yay0_decompress(
         dst_len: *mut usize,
         dst: *mut u8,
         src_len: usize,
@@ -254,7 +254,7 @@ mod c_bindings {
             Ok(d) => d,
         };
 
-        let data = match super::decompress_yay0(&bytes) {
+        let data = match super::yay0_decompress(&bytes) {
             Err(e) => return e,
             Ok(d) => d,
         };
@@ -267,7 +267,7 @@ mod c_bindings {
     }
 
     #[no_mangle]
-    pub extern "C" fn crunch64_compress_yay0_bound(
+    pub extern "C" fn crunch64_yay0_compress_bound(
         dst_size: *mut usize,
         src_len: usize,
         src: *const u8,
@@ -285,7 +285,7 @@ mod c_bindings {
     }
 
     #[no_mangle]
-    pub extern "C" fn crunch64_compress_yay0(
+    pub extern "C" fn crunch64_yay0_compress(
         dst_len: *mut usize,
         dst: *mut u8,
         src_len: usize,
@@ -300,7 +300,7 @@ mod c_bindings {
             Ok(d) => d,
         };
 
-        let data = match super::compress_yay0(&bytes) {
+        let data = match super::yay0_compress(&bytes) {
             Err(e) => return e,
             Ok(d) => d,
         };
@@ -347,7 +347,7 @@ mod tests {
         let compressed_file = &read_test_file(path.clone());
         let decompressed_file = &read_test_file(path.with_extension(""));
 
-        let decompressed = super::decompress_yay0(compressed_file)?;
+        let decompressed = super::yay0_decompress(compressed_file)?;
         assert_eq!(decompressed_file, decompressed.as_ref());
         Ok(())
     }
@@ -359,7 +359,7 @@ mod tests {
         let compressed_file = &read_test_file(path.clone());
         let decompressed_file = &read_test_file(path.with_extension(""));
 
-        let compressed = super::compress_yay0(decompressed_file.as_slice())?;
+        let compressed = super::yay0_compress(decompressed_file.as_slice())?;
         assert_eq!(compressed_file, compressed.as_ref());
         Ok(())
     }
@@ -372,7 +372,7 @@ mod tests {
 
         assert_eq!(
             decompressed_file,
-            super::decompress_yay0(&super::compress_yay0(decompressed_file.as_ref())?)?.as_ref()
+            super::yay0_decompress(&super::yay0_compress(decompressed_file.as_ref())?)?.as_ref()
         );
         Ok(())
     }
@@ -385,7 +385,7 @@ mod tests {
 
         assert_eq!(
             compressed_file,
-            super::compress_yay0(&super::decompress_yay0(compressed_file.as_ref())?)?.as_ref()
+            super::yay0_compress(&super::yay0_decompress(compressed_file.as_ref())?)?.as_ref()
         );
         Ok(())
     }

--- a/lib/src/yaz0.rs
+++ b/lib/src/yaz0.rs
@@ -27,7 +27,7 @@ fn write_header(dst: &mut Vec<u8>, uncompressed_size: usize) -> Result<(), Crunc
     Ok(())
 }
 
-pub fn yaz0_decompress(bytes: &[u8]) -> Result<Box<[u8]>, Crunch64Error> {
+pub fn decompress(bytes: &[u8]) -> Result<Box<[u8]>, Crunch64Error> {
     let uncompressed_size = parse_header(bytes)?;
 
     // Skip the header
@@ -93,7 +93,7 @@ fn size_for_compressed_buffer(input_size: usize) -> Result<usize, Crunch64Error>
     Ok(input_size + divide_round_up(input_size, 8) + 0x10)
 }
 
-pub fn yaz0_compress(bytes: &[u8]) -> Result<Box<[u8]>, Crunch64Error> {
+pub fn compress(bytes: &[u8]) -> Result<Box<[u8]>, Crunch64Error> {
     let input_size = bytes.len();
 
     let mut output: Vec<u8> = Vec::with_capacity(size_for_compressed_buffer(input_size)?);
@@ -244,7 +244,7 @@ mod c_bindings {
             Ok(d) => d,
         };
 
-        let data = match super::yaz0_decompress(&bytes) {
+        let data = match super::decompress(&bytes) {
             Err(e) => return e,
             Ok(d) => d,
         };
@@ -290,7 +290,7 @@ mod c_bindings {
             Ok(d) => d,
         };
 
-        let data = match super::yaz0_compress(&bytes) {
+        let data = match super::compress(&bytes) {
             Err(e) => return e,
             Ok(d) => d,
         };
@@ -337,7 +337,7 @@ mod tests {
         let compressed_file = &read_test_file(path.clone());
         let decompressed_file = &read_test_file(path.with_extension(""));
 
-        let decompressed: Box<[u8]> = super::yaz0_decompress(compressed_file)?;
+        let decompressed: Box<[u8]> = super::decompress(compressed_file)?;
         assert_eq!(decompressed_file, decompressed.as_ref());
         Ok(())
     }
@@ -349,7 +349,7 @@ mod tests {
         let compressed_file = &read_test_file(path.clone());
         let decompressed_file = &read_test_file(path.with_extension(""));
 
-        let compressed = super::yaz0_compress(decompressed_file.as_slice())?;
+        let compressed = super::compress(decompressed_file.as_slice())?;
         assert_eq!(compressed_file, compressed.as_ref());
         Ok(())
     }
@@ -362,7 +362,7 @@ mod tests {
 
         assert_eq!(
             decompressed_file,
-            super::yaz0_decompress(&super::yaz0_compress(decompressed_file.as_ref())?)?.as_ref()
+            super::decompress(&super::compress(decompressed_file.as_ref())?)?.as_ref()
         );
         Ok(())
     }
@@ -375,7 +375,7 @@ mod tests {
 
         assert_eq!(
             compressed_file,
-            super::yaz0_compress(&super::yaz0_decompress(compressed_file.as_ref())?)?.as_ref()
+            super::compress(&super::decompress(compressed_file.as_ref())?)?.as_ref()
         );
         Ok(())
     }


### PR DESCRIPTION
- Removes the format type from function names
  - For example `decompress_yaz0` becomes `decompress`
  - It is recommended to use `yaz0::decompress` instead (or `crunch64::yaz0::decompress`)
- Because C has no concept of namespaces, their bindings keep the format type in the name, but the order was swapped with the action.
  - For example `crunch64_decompress_yaz0` becomes `crunch64_yaz0_decompress`
