### PR TITLE
Try to fix ci for release

### DIFF
--- a/.github/workflows/maturin_upload_pypi.yml
+++ b/.github/workflows/maturin_upload_pypi.yml
@@ -29,7 +29,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist --find-interpreter
+          args: --release --out ../dist --find-interpreter
           sccache: 'true'
           manylinux: auto
           working-directory: lib/
@@ -56,7 +56,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist --find-interpreter
+          args: --release --out ../dist --find-interpreter
           sccache: 'true'
           working-directory: lib/
       - name: Upload wheels
@@ -81,7 +81,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist --find-interpreter
+          args: --release --out ../dist --find-interpreter
           sccache: 'true'
           working-directory: lib/
       - name: Upload wheels
@@ -103,7 +103,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           command: sdist
-          args: --out dist
+          args: --out ../dist
           working-directory: lib/
 
       - name: Upload sdist

--- a/.github/workflows/maturin_upload_pypi.yml
+++ b/.github/workflows/maturin_upload_pypi.yml
@@ -43,6 +43,7 @@ jobs:
         with:
           name: wheels
           path: dist
+          if-no-files-found: error
 
   windows:
     runs-on: windows-latest
@@ -68,6 +69,7 @@ jobs:
         with:
           name: wheels
           path: dist
+          if-no-files-found: error
 
   macos:
     runs-on: macos-latest
@@ -92,6 +94,7 @@ jobs:
         with:
           name: wheels
           path: dist
+          if-no-files-found: error
 
   sdist:
     runs-on: ubuntu-latest
@@ -110,6 +113,7 @@ jobs:
         with:
           name: wheels
           path: dist
+          if-no-files-found: error
 
   release:
     name: Release

--- a/.github/workflows/maturin_upload_pypi.yml
+++ b/.github/workflows/maturin_upload_pypi.yml
@@ -7,11 +7,6 @@ name: Upload to PyPI
 
 on:
   push:
-    branches:
-      - main
-      - master
-    tags:
-      - '*'
   pull_request:
   workflow_dispatch:
 
@@ -101,13 +96,16 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
       - name: Build sdist
         uses: PyO3/maturin-action@v1
         with:
           command: sdist
           args: --out dist
           working-directory: lib/
+
       - name: Upload sdist
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,10 @@
+name: Rust crate release
+
 on:
-    release:
-      types: [created]
+  push:
+  pull_request:
+  workflow_dispatch:
+
 jobs:
   release:
     name: release ${{ matrix.target }}
@@ -8,19 +12,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
+        include: # https://github.com/rust-build/rust-build.action#supported-targets
           - target: x86_64-pc-windows-gnu
-            archive: zip
-          - target: x86_64-pc-windows-msvc
             archive: zip
           - target: x86_64-apple-darwin
             archive: zip
           - target: x86_64-unknown-linux-musl
             archive: tar.gz
-          - target: x86_64-unknown-linux-gnu
-            archive: tar.gz
+
     steps:
-      - uses: actions/checkout@master
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
       - name: Compile and release
         uses: rust-build/rust-build.action@v1.4.4
         env:
@@ -32,11 +35,16 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name:
+        uses: actions-rs/toolchain@v1
         with:
-            toolchain: stable
-            override: true
+          toolchain: stable
+          override: true
+
       - uses: katyo/publish-crates@v2
+        if: "startsWith(github.ref, 'refs/tags/')"
         with:
-            registry-token: ${{ secrets.CRATE_AUTH_TOKEN }}
+          registry-token: ${{ secrets.CRATE_AUTH_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,8 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
 
-      - name: Compile and release cli
+      - name: Compile cli for artifact
+        id: compile_cli
         uses: rust-build/rust-build.action@v1.4.4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -32,7 +33,26 @@ jobs:
           RUSTTARGET: ${{ matrix.target }}
           ARCHIVE_TYPES: ${{ matrix.archive }}
           SRC_DIR: cli/
+          UPLOAD_MODE: none
 
+      - name: Upload cli artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: crunch64-cli
+          path: |
+            ${{ steps.compile_cli.outputs.BUILT_ARCHIVE }}
+            ${{ steps.compile_cli.outputs.BUILT_CHECKSUM }}
+
+      - name: Compile and release cli
+        uses: rust-build/rust-build.action@v1.4.4
+        if: "startsWith(github.ref, 'refs/tags/')"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          RUSTTARGET: ${{ matrix.target }}
+          ARCHIVE_TYPES: ${{ matrix.archive }}
+          SRC_DIR: cli/
+          UPLOAD_MODE: release
   publish:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Upload cli artifact
         uses: actions/upload-artifact@v3
         with:
-          name: crunch64-cli
+          name: crunch64-cli-${{ matrix.target }}
           path: |
             ${{ steps.compile_cli.outputs.BUILT_ARCHIVE }}
             ${{ steps.compile_cli.outputs.BUILT_CHECKSUM }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Rust crate release
+name: Rust crate and cli release
 
 on:
   push:
@@ -24,14 +24,14 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
 
-      - name: Compile and release library
+      - name: Compile and release cli
         uses: rust-build/rust-build.action@v1.4.4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           RUSTTARGET: ${{ matrix.target }}
           ARCHIVE_TYPES: ${{ matrix.archive }}
-          SRC_DIR: lib/
+          SRC_DIR: cli/
 
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,13 +24,14 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
 
-      - name: Compile and release
+      - name: Compile and release library
         uses: rust-build/rust-build.action@v1.4.4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           RUSTTARGET: ${{ matrix.target }}
           ARCHIVE_TYPES: ${{ matrix.archive }}
+          SRC_DIR: lib/
 
   publish:
     runs-on: ubuntu-latest
@@ -38,13 +39,14 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
 
-      - name:
+      - name: Setup Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
           override: true
 
-      - uses: katyo/publish-crates@v2
+      - name: Publish crate
+        uses: katyo/publish-crates@v2
         if: "startsWith(github.ref, 'refs/tags/')"
         with:
           registry-token: ${{ secrets.CRATE_AUTH_TOKEN }}


### PR DESCRIPTION
I think this should fix everything for the Python and Rust releases.

Something to note is that I changed those two GHA to be run on every branch (without actually making a release ofc) and to try to fail if files can't be found. This way we should be able to detect this kind of issues way earlier than the actual release