### PR TITLE
Small code cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - CHANGELOG.md file.
 
+### Changed
+
+- A few code cleanups.
+
 ## [0.2.0] - 2023-12-28
 
 ### Added

--- a/lib/src/mio0.rs
+++ b/lib/src/mio0.rs
@@ -100,14 +100,10 @@ pub fn compress(bytes: &[u8]) -> Result<Box<[u8]>, Crunch64Error> {
     let mut cur_layout_bit: u32 = 0x80000000;
 
     while input_pos < input_size {
-        let mut group_pos: i32 = 0;
-        let mut group_size: u32 = 0;
+        let mut group_pos: i32;
+        let mut group_size: u32;
 
-        (group_pos, group_size) = utils::search(
-            input_pos,
-            bytes,
-            18,
-        );
+        (group_pos, group_size) = utils::search(input_pos, bytes, 18);
 
         // If the group isn't larger than 2 bytes, copying the input without compression is smaller
         if group_size <= 2 {
@@ -116,15 +112,11 @@ pub fn compress(bytes: &[u8]) -> Result<Box<[u8]>, Crunch64Error> {
             def.push(bytes[input_pos]);
             input_pos += 1;
         } else {
-            let mut new_size: u32 = 0;
-            let mut new_position: i32 = 0;
+            let new_size: u32;
+            let new_position: i32;
 
             // Search for a new group after one position after the current one
-            (new_position, new_size) = utils::search(
-                input_pos + 1,
-                bytes,
-                18,
-            );
+            (new_position, new_size) = utils::search(input_pos + 1, bytes, 18);
 
             // If the new group is better than the current group by at least 2 bytes, use it instead
             if new_size >= group_size + 2 {

--- a/lib/src/mio0.rs
+++ b/lib/src/mio0.rs
@@ -100,10 +100,7 @@ pub fn compress(bytes: &[u8]) -> Result<Box<[u8]>, Crunch64Error> {
     let mut cur_layout_bit: u32 = 0x80000000;
 
     while input_pos < input_size {
-        let mut group_pos: i32;
-        let mut group_size: u32;
-
-        (group_pos, group_size) = utils::search(input_pos, bytes, 18);
+        let (mut group_pos, mut group_size) = utils::search(input_pos, bytes, 18);
 
         // If the group isn't larger than 2 bytes, copying the input without compression is smaller
         if group_size <= 2 {
@@ -112,11 +109,8 @@ pub fn compress(bytes: &[u8]) -> Result<Box<[u8]>, Crunch64Error> {
             def.push(bytes[input_pos]);
             input_pos += 1;
         } else {
-            let new_size: u32;
-            let new_position: i32;
-
             // Search for a new group after one position after the current one
-            (new_position, new_size) = utils::search(input_pos + 1, bytes, 18);
+            let (new_position, new_size) = utils::search(input_pos + 1, bytes, 18);
 
             // If the new group is better than the current group by at least 2 bytes, use it instead
             if new_size >= group_size + 2 {

--- a/lib/src/mio0.rs
+++ b/lib/src/mio0.rs
@@ -105,7 +105,6 @@ pub fn compress(bytes: &[u8]) -> Result<Box<[u8]>, Crunch64Error> {
 
         utils::search(
             input_pos,
-            input_size,
             &mut group_pos,
             &mut group_size,
             bytes,
@@ -125,7 +124,6 @@ pub fn compress(bytes: &[u8]) -> Result<Box<[u8]>, Crunch64Error> {
             // Search for a new group after one position after the current one
             utils::search(
                 input_pos + 1,
-                input_size,
                 &mut new_position,
                 &mut new_size,
                 bytes,

--- a/lib/src/mio0.rs
+++ b/lib/src/mio0.rs
@@ -103,10 +103,8 @@ pub fn compress(bytes: &[u8]) -> Result<Box<[u8]>, Crunch64Error> {
         let mut group_pos: i32 = 0;
         let mut group_size: u32 = 0;
 
-        utils::search(
+        (group_pos, group_size) = utils::search(
             input_pos,
-            &mut group_pos,
-            &mut group_size,
             bytes,
             18,
         );
@@ -122,10 +120,8 @@ pub fn compress(bytes: &[u8]) -> Result<Box<[u8]>, Crunch64Error> {
             let mut new_position: i32 = 0;
 
             // Search for a new group after one position after the current one
-            utils::search(
+            (new_position, new_size) = utils::search(
                 input_pos + 1,
-                &mut new_position,
-                &mut new_size,
                 bytes,
                 18,
             );

--- a/lib/src/utils.rs
+++ b/lib/src/utils.rs
@@ -78,14 +78,10 @@ pub(crate) fn set_pointer_array_from_u8_array(
     Ok(())
 }
 
-pub(crate) fn search(
-    input_pos: usize,
-    data_in: &[u8],
-    max_match_length: usize,
-) -> (i32, u32) {
-    let mut cur_size: usize = 3;
-    let mut found_pos: isize = 0;
-    let mut search_pos: usize = cmp::max(input_pos as isize - 0x1000, 0) as usize;
+pub(crate) fn search(input_pos: usize, data_in: &[u8], max_match_length: usize) -> (i32, u32) {
+    let mut cur_size = 3;
+    let mut found_pos = 0;
+    let mut search_pos = cmp::max(input_pos as isize - 0x1000, 0) as usize;
     let search_size = cmp::min(data_in.len() - input_pos, max_match_length);
 
     if search_size < 3 {
@@ -120,12 +116,7 @@ pub(crate) fn search(
         cur_size += 1;
     }
 
-    if cur_size > 3 {
-        cur_size -= 1;
-        return (found_pos as i32, cur_size as u32);
-    }
-
-    (found_pos as i32, 0)
+    (found_pos as i32, cmp::max(cur_size as isize - 1, 0) as u32)
 }
 
 fn mischarsearch(pattern: &[u8], pattern_len: usize, data: &[u8], data_len: usize) -> usize {

--- a/lib/src/utils.rs
+++ b/lib/src/utils.rs
@@ -80,20 +80,16 @@ pub(crate) fn set_pointer_array_from_u8_array(
 
 pub(crate) fn search(
     input_pos: usize,
-    pos_out: &mut i32,
-    size_out: &mut u32,
     data_in: &[u8],
     max_match_length: usize,
-) {
+) -> (i32, u32) {
     let mut cur_size: usize = 3;
     let mut found_pos: isize = 0;
     let mut search_pos: usize = cmp::max(input_pos as isize - 0x1000, 0) as usize;
     let search_size = cmp::min(data_in.len() - input_pos, max_match_length);
 
     if search_size < 3 {
-        *pos_out = 0;
-        *size_out = 0;
-        return;
+        return (0, 0);
     }
 
     while search_pos < input_pos {
@@ -116,9 +112,7 @@ pub(crate) fn search(
         }
 
         if search_size == cur_size {
-            *pos_out = (found_offset + search_pos) as i32;
-            *size_out = cur_size as u32;
-            return;
+            return ((found_offset + search_pos) as i32, cur_size as u32);
         }
 
         found_pos = (search_pos + found_offset) as isize;
@@ -126,13 +120,12 @@ pub(crate) fn search(
         cur_size += 1;
     }
 
-    *pos_out = found_pos as i32;
     if cur_size > 3 {
         cur_size -= 1;
-        *size_out = cur_size as u32;
-        return;
+        return (found_pos as i32, cur_size as u32);
     }
-    *size_out = 0;
+
+    (found_pos as i32, 0)
 }
 
 fn mischarsearch(pattern: &[u8], pattern_len: usize, data: &[u8], data_len: usize) -> usize {

--- a/lib/src/utils.rs
+++ b/lib/src/utils.rs
@@ -80,7 +80,6 @@ pub(crate) fn set_pointer_array_from_u8_array(
 
 pub(crate) fn search(
     input_pos: usize,
-    input_size: usize,
     pos_out: &mut i32,
     size_out: &mut u32,
     data_in: &[u8],
@@ -89,7 +88,7 @@ pub(crate) fn search(
     let mut cur_size: usize = 3;
     let mut found_pos: isize = 0;
     let mut search_pos: usize = cmp::max(input_pos as isize - 0x1000, 0) as usize;
-    let search_size = cmp::min(input_size - input_pos, max_match_length);
+    let search_size = cmp::min(data_in.len() - input_pos, max_match_length);
 
     if search_size >= 3 {
         while search_pos < input_pos {

--- a/lib/src/utils.rs
+++ b/lib/src/utils.rs
@@ -90,45 +90,47 @@ pub(crate) fn search(
     let mut search_pos: usize = cmp::max(input_pos as isize - 0x1000, 0) as usize;
     let search_size = cmp::min(data_in.len() - input_pos, max_match_length);
 
-    if search_size >= 3 {
-        while search_pos < input_pos {
-            let found_offset = mischarsearch(
-                &data_in[input_pos..],
-                cur_size,
-                &data_in[search_pos..],
-                cur_size + input_pos - search_pos,
-            );
+    if search_size < 3 {
+        *pos_out = 0;
+        *size_out = 0;
+        return;
+    }
 
-            if found_offset >= input_pos - search_pos {
+    while search_pos < input_pos {
+        let found_offset = mischarsearch(
+            &data_in[input_pos..],
+            cur_size,
+            &data_in[search_pos..],
+            cur_size + input_pos - search_pos,
+        );
+
+        if found_offset >= input_pos - search_pos {
+            break;
+        }
+
+        while cur_size < search_size {
+            if data_in[cur_size + search_pos + found_offset] != data_in[cur_size + input_pos] {
                 break;
             }
-
-            while cur_size < search_size {
-                if data_in[cur_size + search_pos + found_offset] != data_in[cur_size + input_pos] {
-                    break;
-                }
-                cur_size += 1;
-            }
-
-            if search_size == cur_size {
-                *pos_out = (found_offset + search_pos) as i32;
-                *size_out = cur_size as u32;
-                return;
-            }
-
-            found_pos = (search_pos + found_offset) as isize;
-            search_pos = (found_pos + 1) as usize;
             cur_size += 1;
         }
 
-        *pos_out = found_pos as i32;
-        if cur_size > 3 {
-            cur_size -= 1;
+        if search_size == cur_size {
+            *pos_out = (found_offset + search_pos) as i32;
             *size_out = cur_size as u32;
             return;
         }
-    } else {
-        *pos_out = 0;
+
+        found_pos = (search_pos + found_offset) as isize;
+        search_pos = (found_pos + 1) as usize;
+        cur_size += 1;
+    }
+
+    *pos_out = found_pos as i32;
+    if cur_size > 3 {
+        cur_size -= 1;
+        *size_out = cur_size as u32;
+        return;
     }
     *size_out = 0;
 }

--- a/lib/src/utils.rs
+++ b/lib/src/utils.rs
@@ -78,7 +78,7 @@ pub(crate) fn set_pointer_array_from_u8_array(
     Ok(())
 }
 
-pub(crate) fn search(input_pos: usize, data_in: &[u8], max_match_length: usize) -> (i32, u32) {
+pub(crate) fn search(input_pos: usize, data_in: &[u8], max_match_length: usize) -> (u32, u32) {
     let mut cur_size = 3;
     let mut found_pos = 0;
     let mut search_pos = cmp::max(input_pos as isize - 0x1000, 0) as usize;
@@ -108,7 +108,7 @@ pub(crate) fn search(input_pos: usize, data_in: &[u8], max_match_length: usize) 
         }
 
         if search_size == cur_size {
-            return ((found_offset + search_pos) as i32, cur_size as u32);
+            return ((found_offset + search_pos) as u32, cur_size as u32);
         }
 
         found_pos = (search_pos + found_offset) as isize;
@@ -116,7 +116,7 @@ pub(crate) fn search(input_pos: usize, data_in: &[u8], max_match_length: usize) 
         cur_size += 1;
     }
 
-    (found_pos as i32, cmp::max(cur_size as isize - 1, 0) as u32)
+    (found_pos as u32, cmp::max(cur_size as isize - 1, 0) as u32)
 }
 
 fn mischarsearch(pattern: &[u8], pattern_len: usize, data: &[u8], data_len: usize) -> usize {
@@ -127,7 +127,7 @@ fn mischarsearch(pattern: &[u8], pattern_len: usize, data: &[u8], data_len: usiz
     let mut j: isize;
 
     if pattern_len <= data_len {
-        initskip(pattern, pattern_len as i32, &mut skip_table);
+        initskip(pattern, pattern_len, &mut skip_table);
 
         i = pattern_len as isize - 1;
         loop {
@@ -160,10 +160,10 @@ fn mischarsearch(pattern: &[u8], pattern_len: usize, data: &[u8], data_len: usiz
     data_len
 }
 
-fn initskip(pattern: &[u8], len: i32, skip: &mut [u16; 256]) {
+fn initskip(pattern: &[u8], len: usize, skip: &mut [u16; 256]) {
     skip.fill(len as u16);
 
     for i in 0..len {
-        skip[pattern[i as usize] as usize] = (len - i - 1) as u16;
+        skip[pattern[i] as usize] = (len - i - 1) as u16;
     }
 }

--- a/lib/src/yay0.rs
+++ b/lib/src/yay0.rs
@@ -108,10 +108,7 @@ pub fn compress(bytes: &[u8]) -> Result<Box<[u8]>, Crunch64Error> {
     let mut cur_layout_bit: u32 = 0x80000000;
 
     while input_pos < input_size {
-        let mut group_pos: i32;
-        let mut group_size: u32;
-
-        (group_pos, group_size) = utils::search(input_pos, bytes, 0x111);
+        let (mut group_pos, mut group_size) = utils::search(input_pos, bytes, 0x111);
 
         // If the group isn't larger than 2 bytes, copying the input without compression is smaller
         if group_size <= 2 {
@@ -120,11 +117,8 @@ pub fn compress(bytes: &[u8]) -> Result<Box<[u8]>, Crunch64Error> {
             def.push(bytes[input_pos]);
             input_pos += 1;
         } else {
-            let new_size: u32;
-            let new_position: i32;
-
             // Search for a new group after one position after the current one
-            (new_position, new_size) = utils::search(input_pos + 1, bytes, 0x111);
+            let (new_position, new_size) = utils::search(input_pos + 1, bytes, 0x111);
 
             // If the new group is better than the current group by at least 2 bytes, use it instead
             if new_size >= group_size + 2 {

--- a/lib/src/yay0.rs
+++ b/lib/src/yay0.rs
@@ -113,7 +113,6 @@ pub fn compress(bytes: &[u8]) -> Result<Box<[u8]>, Crunch64Error> {
 
         utils::search(
             input_pos,
-            input_size,
             &mut group_pos,
             &mut group_size,
             bytes,
@@ -133,7 +132,6 @@ pub fn compress(bytes: &[u8]) -> Result<Box<[u8]>, Crunch64Error> {
             // Search for a new group after one position after the current one
             utils::search(
                 input_pos + 1,
-                input_size,
                 &mut new_position,
                 &mut new_size,
                 bytes,

--- a/lib/src/yay0.rs
+++ b/lib/src/yay0.rs
@@ -108,14 +108,10 @@ pub fn compress(bytes: &[u8]) -> Result<Box<[u8]>, Crunch64Error> {
     let mut cur_layout_bit: u32 = 0x80000000;
 
     while input_pos < input_size {
-        let mut group_pos: i32 = 0;
-        let mut group_size: u32 = 0;
+        let mut group_pos: i32;
+        let mut group_size: u32;
 
-        (group_pos, group_size) = utils::search(
-            input_pos,
-            bytes,
-            0x111,
-        );
+        (group_pos, group_size) = utils::search(input_pos, bytes, 0x111);
 
         // If the group isn't larger than 2 bytes, copying the input without compression is smaller
         if group_size <= 2 {
@@ -124,16 +120,11 @@ pub fn compress(bytes: &[u8]) -> Result<Box<[u8]>, Crunch64Error> {
             def.push(bytes[input_pos]);
             input_pos += 1;
         } else {
-            let mut new_size: u32 = 0;
-            let mut new_position: i32 = 0;
+            let new_size: u32;
+            let new_position: i32;
 
             // Search for a new group after one position after the current one
-            (new_position,
-new_size) = utils::search(
-                input_pos + 1,
-                bytes,
-                0x111,
-            );
+            (new_position, new_size) = utils::search(input_pos + 1, bytes, 0x111);
 
             // If the new group is better than the current group by at least 2 bytes, use it instead
             if new_size >= group_size + 2 {

--- a/lib/src/yay0.rs
+++ b/lib/src/yay0.rs
@@ -111,10 +111,8 @@ pub fn compress(bytes: &[u8]) -> Result<Box<[u8]>, Crunch64Error> {
         let mut group_pos: i32 = 0;
         let mut group_size: u32 = 0;
 
-        utils::search(
+        (group_pos, group_size) = utils::search(
             input_pos,
-            &mut group_pos,
-            &mut group_size,
             bytes,
             0x111,
         );
@@ -130,10 +128,9 @@ pub fn compress(bytes: &[u8]) -> Result<Box<[u8]>, Crunch64Error> {
             let mut new_position: i32 = 0;
 
             // Search for a new group after one position after the current one
-            utils::search(
+            (new_position,
+new_size) = utils::search(
                 input_pos + 1,
-                &mut new_position,
-                &mut new_size,
                 bytes,
                 0x111,
             );

--- a/lib/src/yaz0.rs
+++ b/lib/src/yaz0.rs
@@ -112,7 +112,6 @@ pub fn compress(bytes: &[u8]) -> Result<Box<[u8]>, Crunch64Error> {
 
         utils::search(
             input_pos,
-            input_size,
             &mut group_pos,
             &mut group_size,
             bytes,
@@ -133,7 +132,6 @@ pub fn compress(bytes: &[u8]) -> Result<Box<[u8]>, Crunch64Error> {
             // Search for a new group after one position after the current one
             utils::search(
                 input_pos + 1,
-                input_size,
                 &mut new_position,
                 &mut new_size,
                 bytes,

--- a/lib/src/yaz0.rs
+++ b/lib/src/yaz0.rs
@@ -107,10 +107,7 @@ pub fn compress(bytes: &[u8]) -> Result<Box<[u8]>, Crunch64Error> {
     let mut cur_layout_bit: u8 = 0x80;
 
     while input_pos < input_size {
-        let mut group_pos: i32;
-        let mut group_size: u32;
-
-        (group_pos, group_size) = utils::search(input_pos, bytes, 0x111);
+        let (mut group_pos, mut group_size) = utils::search(input_pos, bytes, 0x111);
 
         // If the group isn't larger than 2 bytes, copying the input without compression is smaller
         if group_size <= 2 {
@@ -120,11 +117,8 @@ pub fn compress(bytes: &[u8]) -> Result<Box<[u8]>, Crunch64Error> {
             input_pos += 1;
             index_out_ptr += 1;
         } else {
-            let new_size: u32;
-            let new_position: i32;
-
             // Search for a new group after one position after the current one
-            (new_position, new_size) = utils::search(input_pos + 1, bytes, 0x111);
+            let (new_position, new_size) = utils::search(input_pos + 1, bytes, 0x111);
 
             // If the new group is better than the current group by at least 2 bytes, use it instead
             if new_size >= group_size + 2 {
@@ -150,7 +144,7 @@ pub fn compress(bytes: &[u8]) -> Result<Box<[u8]>, Crunch64Error> {
             }
 
             // Calculate the offset for the current group
-            let group_offset: u32 = (input_pos as i32 - group_pos - 1) as u32;
+            let group_offset = input_pos as u32 - group_pos - 1;
 
             // Determine which encoding to use for the current group
             if group_size >= 0x12 {

--- a/lib/src/yaz0.rs
+++ b/lib/src/yaz0.rs
@@ -110,10 +110,9 @@ pub fn compress(bytes: &[u8]) -> Result<Box<[u8]>, Crunch64Error> {
         let mut group_pos: i32 = 0;
         let mut group_size: u32 = 0;
 
-        utils::search(
+        (group_pos,
+            group_size) = utils::search(
             input_pos,
-            &mut group_pos,
-            &mut group_size,
             bytes,
             0x111,
         );
@@ -130,10 +129,9 @@ pub fn compress(bytes: &[u8]) -> Result<Box<[u8]>, Crunch64Error> {
             let mut new_position: i32 = 0;
 
             // Search for a new group after one position after the current one
-            utils::search(
+            (new_position,
+                new_size) = utils::search(
                 input_pos + 1,
-                &mut new_position,
-                &mut new_size,
                 bytes,
                 0x111,
             );

--- a/lib/src/yaz0.rs
+++ b/lib/src/yaz0.rs
@@ -107,15 +107,10 @@ pub fn compress(bytes: &[u8]) -> Result<Box<[u8]>, Crunch64Error> {
     let mut cur_layout_bit: u8 = 0x80;
 
     while input_pos < input_size {
-        let mut group_pos: i32 = 0;
-        let mut group_size: u32 = 0;
+        let mut group_pos: i32;
+        let mut group_size: u32;
 
-        (group_pos,
-            group_size) = utils::search(
-            input_pos,
-            bytes,
-            0x111,
-        );
+        (group_pos, group_size) = utils::search(input_pos, bytes, 0x111);
 
         // If the group isn't larger than 2 bytes, copying the input without compression is smaller
         if group_size <= 2 {
@@ -125,16 +120,11 @@ pub fn compress(bytes: &[u8]) -> Result<Box<[u8]>, Crunch64Error> {
             input_pos += 1;
             index_out_ptr += 1;
         } else {
-            let mut new_size: u32 = 0;
-            let mut new_position: i32 = 0;
+            let new_size: u32;
+            let new_position: i32;
 
             // Search for a new group after one position after the current one
-            (new_position,
-                new_size) = utils::search(
-                input_pos + 1,
-                bytes,
-                0x111,
-            );
+            (new_position, new_size) = utils::search(input_pos + 1, bytes, 0x111);
 
             // If the new group is better than the current group by at least 2 bytes, use it instead
             if new_size >= group_size + 2 {


### PR DESCRIPTION
`search` taking two mut references instead of returning a tuple. I also cleaned up that function a bit.

The diff looks better by ignoring the whitespace