### PR TITLE
Cow arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - A few code cleanups.
 
+### Fixed
+
+- Functions not accepting `bytearray` objects.
+
 ## [0.2.0] - 2023-12-28
 
 ### Added

--- a/lib/src/mio0.rs
+++ b/lib/src/mio0.rs
@@ -287,14 +287,21 @@ pub(crate) mod python_bindings {
     use pyo3::prelude::*;
     use std::borrow::Cow;
 
+    /**
+     * We use a `Cow` instead of a plain &[u8] because the latter only allows Python's
+     * `bytes` objects, while `Cow`` allows for both `bytes` and `bytearray`.
+     * This is important because an argument typed as `bytes` allows to pass a
+     * `bytearray` object too.
+     */
+
     #[pyfunction]
-    pub(crate) fn decompress_mio0(bytes: &[u8]) -> Result<Cow<[u8]>, super::Crunch64Error> {
-        Ok(Cow::Owned(super::decompress(bytes)?.into()))
+    pub(crate) fn decompress_mio0(bytes: Cow<[u8]>) -> Result<Cow<[u8]>, super::Crunch64Error> {
+        Ok(Cow::Owned(super::decompress(&bytes)?.into()))
     }
 
     #[pyfunction]
-    pub(crate) fn compress_mio0(bytes: &[u8]) -> Result<Cow<[u8]>, super::Crunch64Error> {
-        Ok(Cow::Owned(super::compress(bytes)?.into()))
+    pub(crate) fn compress_mio0(bytes: Cow<[u8]>) -> Result<Cow<[u8]>, super::Crunch64Error> {
+        Ok(Cow::Owned(super::compress(&bytes)?.into()))
     }
 }
 

--- a/lib/src/yay0.rs
+++ b/lib/src/yay0.rs
@@ -300,14 +300,21 @@ pub(crate) mod python_bindings {
     use pyo3::prelude::*;
     use std::borrow::Cow;
 
+    /**
+     * We use a `Cow` instead of a plain &[u8] because the latter only allows Python's
+     * `bytes` objects, while `Cow`` allows for both `bytes` and `bytearray`.
+     * This is important because an argument typed as `bytes` allows to pass a
+     * `bytearray` object too.
+     */
+
     #[pyfunction]
-    pub(crate) fn decompress_yay0(bytes: &[u8]) -> Result<Cow<[u8]>, super::Crunch64Error> {
-        Ok(Cow::Owned(super::decompress(bytes)?.into()))
+    pub(crate) fn decompress_yay0(bytes: Cow<[u8]>) -> Result<Cow<[u8]>, super::Crunch64Error> {
+        Ok(Cow::Owned(super::decompress(&bytes)?.into()))
     }
 
     #[pyfunction]
-    pub(crate) fn compress_yay0(bytes: &[u8]) -> Result<Cow<[u8]>, super::Crunch64Error> {
-        Ok(Cow::Owned(super::compress(bytes)?.into()))
+    pub(crate) fn compress_yay0(bytes: Cow<[u8]>) -> Result<Cow<[u8]>, super::Crunch64Error> {
+        Ok(Cow::Owned(super::compress(&bytes)?.into()))
     }
 }
 

--- a/lib/src/yaz0.rs
+++ b/lib/src/yaz0.rs
@@ -290,14 +290,21 @@ pub(crate) mod python_bindings {
     use pyo3::prelude::*;
     use std::borrow::Cow;
 
+    /**
+     * We use a `Cow` instead of a plain &[u8] because the latter only allows Python's
+     * `bytes` objects, while `Cow`` allows for both `bytes` and `bytearray`.
+     * This is important because an argument typed as `bytes` allows to pass a
+     * `bytearray` object too.
+     */
+
     #[pyfunction]
-    pub(crate) fn decompress_yaz0(bytes: &[u8]) -> Result<Cow<[u8]>, super::Crunch64Error> {
-        Ok(Cow::Owned(super::decompress(bytes)?.into()))
+    pub(crate) fn decompress_yaz0(bytes: Cow<[u8]>) -> Result<Cow<[u8]>, super::Crunch64Error> {
+        Ok(Cow::Owned(super::decompress(&bytes)?.into()))
     }
 
     #[pyfunction]
-    pub(crate) fn compress_yaz0(bytes: &[u8]) -> Result<Cow<[u8]>, super::Crunch64Error> {
-        Ok(Cow::Owned(super::compress(bytes)?.into()))
+    pub(crate) fn compress_yaz0(bytes: Cow<[u8]>) -> Result<Cow<[u8]>, super::Crunch64Error> {
+        Ok(Cow::Owned(super::compress(&bytes)?.into()))
     }
 }
 


### PR DESCRIPTION
Change the argument of the Python wrappers to use `Cow` instead of an array of u8, because that allows both `bytes` and `bytearray` objects while the array of u8 only allows `bytes` objects