### PR TITLE
Yaz0 bugfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix some rare cases where the Yaz0 compressor may append an extra 0 at the end of the compressed data.
+
 ## [0.3.0] - 2024-1-19
 
 ### Added
@@ -42,7 +46,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Python bindings.
 - C bindings.
 
-[unreleased]: https://github.com/decompals/crunch64/compare/0.2.0...HEAD
+[unreleased]: https://github.com/decompals/crunch64/compare/0.3.0...HEAD
+[0.3.0]: https://github.com/decompals/crunch64/compare/0.2.0...0.3.0
 [0.2.0]: https://github.com/decompals/crunch64/compare/0.1.1...0.2.0
 [0.1.1]: https://github.com/decompals/crunch64/compare/0.1.0...0.1.1
 [0.1.0]: https://github.com/decompals/crunch64/releases/tag/0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,7 +134,7 @@ dependencies = [
 
 [[package]]
 name = "crunch64-cli"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "clap",
  "crunch64",

--- a/lib/src/yaz0.rs
+++ b/lib/src/yaz0.rs
@@ -100,13 +100,15 @@ pub fn compress(bytes: &[u8]) -> Result<Box<[u8]>, Crunch64Error> {
 
     write_header(&mut output, input_size)?;
 
-    output.push(0);
     let mut index_cur_layout_byte: usize = 0x10;
-    let mut index_out_ptr: usize = index_cur_layout_byte + 1;
+    let mut index_out_ptr: usize = index_cur_layout_byte;
     let mut input_pos: usize = 0;
-    let mut cur_layout_bit: u8 = 0x80;
+    let mut cur_layout_bit: u8 = 1;
 
     while input_pos < input_size {
+        // Advance to the next layout bit
+        cur_layout_bit >>= 1;
+
         if cur_layout_bit == 0 {
             cur_layout_bit = 0x80;
             index_cur_layout_byte = index_out_ptr;
@@ -173,9 +175,6 @@ pub fn compress(bytes: &[u8]) -> Result<Box<[u8]>, Crunch64Error> {
             // Move forward in the input by the size of the group
             input_pos += group_size as usize;
         }
-
-        // Advance to the next layout bit
-        cur_layout_bit >>= 1;
     }
 
     Ok(output.into_boxed_slice())

--- a/lib/src/yaz0.rs
+++ b/lib/src/yaz0.rs
@@ -107,6 +107,13 @@ pub fn compress(bytes: &[u8]) -> Result<Box<[u8]>, Crunch64Error> {
     let mut cur_layout_bit: u8 = 0x80;
 
     while input_pos < input_size {
+        if cur_layout_bit == 0 {
+            cur_layout_bit = 0x80;
+            index_cur_layout_byte = index_out_ptr;
+            output.push(0);
+            index_out_ptr += 1;
+        }
+
         let (mut group_pos, mut group_size) = utils::search(input_pos, bytes, 0x111);
 
         // If the group isn't larger than 2 bytes, copying the input without compression is smaller
@@ -169,13 +176,6 @@ pub fn compress(bytes: &[u8]) -> Result<Box<[u8]>, Crunch64Error> {
 
         // Advance to the next layout bit
         cur_layout_bit >>= 1;
-
-        if cur_layout_bit == 0 {
-            cur_layout_bit = 0x80;
-            index_cur_layout_byte = index_out_ptr;
-            output.push(0);
-            index_out_ptr += 1;
-        }
     }
 
     Ok(output.into_boxed_slice())


### PR DESCRIPTION
Fix some rare cases where the Yaz0 compressor may append an extra 0 at the end of the compressed data.

Sadly none of our test cases catch this problem. Would be nice to have test cases that can reproduce this issue, but sadly all the ones I have are copyrighted materials