### PR TITLE
Add prebuilt binaries for Python 3.13

### DIFF
--- a/.github/workflows/maturin_upload_pypi.yml
+++ b/.github/workflows/maturin_upload_pypi.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.13'
+          python-version: '3.9 - 3.13'
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:

--- a/.github/workflows/maturin_upload_pypi.yml
+++ b/.github/workflows/maturin_upload_pypi.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.13'
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
@@ -50,7 +50,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.13'
           architecture: ${{ matrix.target }}
       - name: Build wheels
         uses: PyO3/maturin-action@v1
@@ -76,7 +76,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.13'
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:

--- a/.github/workflows/maturin_upload_pypi.yml
+++ b/.github/workflows/maturin_upload_pypi.yml
@@ -113,6 +113,26 @@ jobs:
           path: dist
           if-no-files-found: error
 
+  check_clippy_python_bindings:
+    name: Check clippy for Python bindings
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout reposistory
+        uses: actions/checkout@v4
+
+      - name: Setup Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      - name: Setup clippy
+        run: rustup component add clippy
+
+      - name: Run clippy
+        run: cargo clippy --all-targets --features python_bindings -- -D warnings
+
   release:
     name: Release
     runs-on: ubuntu-latest

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -17,9 +17,8 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          python3 -m pip install -r requirements.txt
-          python3 -m pip install -U maturin
           python3 -m pip install -U mypy
 
       - name: mypy
-        run: python3 -m mypy --show-column-numbers --hide-error-context .
+        run: |
+          python3 -m mypy --show-column-numbers --hide-error-context .

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -1,0 +1,25 @@
+name: Check mypy
+
+# Build on every branch push, tag push, and pull request change:
+on: [push, pull_request]
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    name: mypy
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.9
+
+      - name: Install Dependencies
+        run: |
+          python3 -m pip install -r requirements.txt
+          python3 -m pip install -U maturin
+          python3 -m pip install -U mypy
+
+      - name: mypy
+        run: python3 -m mypy --show-column-numbers --hide-error-context .

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -35,3 +35,17 @@ jobs:
       - uses: actions/checkout@v4
       - name: Test
         run: cargo test
+
+  msrv:
+    name: Check MSRV
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout reposistory
+        uses: actions/checkout@v4
+
+      - name: Setup MSRV checker
+        uses: taiki-e/install-action@cargo-hack
+
+      # To find current MSRV use `cargo msrv find`. Install it with `cargo install cargo-msrv --locked`
+      - name: Run MSRV checker
+        run: cargo hack check --rust-version --workspace --all-targets --ignore-private

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Run cargo clippy
         run: |
           cargo clippy --version
-          cargo clippy --all -- -D warnings
+          cargo clippy --all --all-targets --all-features -- -D warnings
 
   macos-check:
     runs-on: macos-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,14 +6,27 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  rustfmt-check:
+  rustfmt:
+    name: Check formatting
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout reposistory
+        uses: actions/checkout@v4
+
       - name: Run cargo fmt
         run: cargo fmt --all -- --check
+
+  clippy:
+    name: Check clippy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout reposistory
+        uses: actions/checkout@v4
+
       - name: Run cargo clippy
-        run: cargo clippy --all -- -D warnings
+        run: |
+          cargo clippy --version
+          cargo clippy --all -- -D warnings
 
   macos-check:
     runs-on: macos-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Prebuilt binaries for Python 3.13.
+- Check Python files with mypy
+
+### Changed
+
+- Python 3.9 or later is now required.
+  - Mainly due to not being able to automatically check for older version in CI.
 
 ## [0.5.1] - 2024-07-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Python 3.9 or later is now required.
-  - Mainly due to not being able to automatically check for older version in CI.
+  - Mainly due to not being able to automatically check and build for older versions in CI.
 
 ## [0.5.1] - 2024-07-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Prebuilt binaries for Python 3.13.
+
 ## [0.5.1] - 2024-07-25
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Prebuilt binaries for Python 3.13.
-- Check Python files with mypy
+- Check Python files with mypy.
+- Set MSRV (minimum supported Rust version) to 1.73.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.2] - 2024-12-15
+
 ### Added
 
 - Prebuilt binaries for Python 3.13.
@@ -84,6 +86,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - C bindings.
 
 [unreleased]: https://github.com/decompals/crunch64/compare/0.5.1...HEAD
+[0.5.2]: https://github.com/decompals/crunch64/compare/0.5.1...0.5.2
 [0.5.1]: https://github.com/decompals/crunch64/compare/0.5.0...0.5.1
 [0.5.0]: https://github.com/decompals/crunch64/compare/0.4.0...0.5.0
 [0.4.0]: https://github.com/decompals/crunch64/compare/0.3.1...0.4.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,7 +134,7 @@ dependencies = [
 
 [[package]]
 name = "crunch64"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "crc32fast",
  "pyo3",
@@ -144,7 +144,7 @@ dependencies = [
 
 [[package]]
 name = "crunch64-cli"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "clap",
  "crunch64",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 description = "A utility for compressing/decompressing files with common n64 formats"
 repository = "https://github.com/decompals/crunch64"
 license = "MIT"
+rust-version = "1.73.0"
 
 [[bin]]
 name = "crunch64"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crunch64-cli"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 description = "A utility for compressing/decompressing files with common n64 formats"
 repository = "https://github.com/decompals/crunch64"
@@ -12,5 +12,5 @@ name = "crunch64"
 path = "src/main.rs"
 
 [dependencies]
-crunch64 = { version = "0.5.1", path = "../lib" }
+crunch64 = { version = "0.5.2", path = "../lib" }
 clap = { version = "4.4.11", features = ["derive"] }

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "crunch64"
 # Version should be synced with lib/pyproject.toml and lib/crunch64/__init__.py
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 description = "A library for handling common compression formats for N64 games"
 repository = "https://github.com/decompals/crunch64"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 description = "A library for handling common compression formats for N64 games"
 repository = "https://github.com/decompals/crunch64"
 license = "MIT"
+rust-version = "1.70.0"
 
 [lib]
 name = "crunch64"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 description = "A library for handling common compression formats for N64 games"
 repository = "https://github.com/decompals/crunch64"
 license = "MIT"
-rust-version = "1.70.0"
+rust-version = "1.73.0"
 
 [lib]
 name = "crunch64"

--- a/lib/crunch64/__init__.py
+++ b/lib/crunch64/__init__.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 # Version should be synced with lib/Cargo.toml and lib/pyproject.toml
-__version_info__ = (0, 5, 1)
+__version_info__ = (0, 5, 2)
 __version__ = ".".join(map(str, __version_info__))
 __author__ = "decompals"
 

--- a/lib/pyproject.toml
+++ b/lib/pyproject.toml
@@ -3,7 +3,7 @@ name = "crunch64"
 # Version should be synced with lib/Cargo.toml and lib/crunch64/__init__.py
 version = "0.5.1"
 description = "A library for handling common compression formats for N64 games"
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 dependencies = [
 ]
 classifiers = [

--- a/lib/src/mio0.rs
+++ b/lib/src/mio0.rs
@@ -77,13 +77,9 @@ pub fn decompress(bytes: &[u8]) -> Result<Box<[u8]>, Crunch64Error> {
     Ok(ret.into_boxed_slice())
 }
 
-fn divide_round_up(a: usize, b: usize) -> usize {
-    (a + b - 1) / b
-}
-
 fn size_for_compressed_buffer(input_size: usize) -> Result<usize, Crunch64Error> {
     // Taken from Yaz0
-    Ok(input_size + divide_round_up(input_size, 8) + 0x10)
+    Ok(input_size + input_size.div_ceil(8) + 0x10)
 }
 
 pub fn compress(bytes: &[u8]) -> Result<Box<[u8]>, Crunch64Error> {

--- a/lib/src/yay0.rs
+++ b/lib/src/yay0.rs
@@ -85,13 +85,9 @@ pub fn decompress(bytes: &[u8]) -> Result<Box<[u8]>, Crunch64Error> {
     Ok(ret.into_boxed_slice())
 }
 
-fn divide_round_up(a: usize, b: usize) -> usize {
-    (a + b - 1) / b
-}
-
 fn size_for_compressed_buffer(input_size: usize) -> Result<usize, Crunch64Error> {
     // Taken from Yaz0
-    Ok(input_size + divide_round_up(input_size, 8) + 0x10)
+    Ok(input_size + input_size.div_ceil(8) + 0x10)
 }
 
 pub fn compress(bytes: &[u8]) -> Result<Box<[u8]>, Crunch64Error> {

--- a/lib/src/yaz0.rs
+++ b/lib/src/yaz0.rs
@@ -82,15 +82,11 @@ pub fn decompress(bytes: &[u8]) -> Result<Box<[u8]>, Crunch64Error> {
     Ok(ret.into_boxed_slice())
 }
 
-fn divide_round_up(a: usize, b: usize) -> usize {
-    (a + b - 1) / b
-}
-
 fn size_for_compressed_buffer(input_size: usize) -> Result<usize, Crunch64Error> {
     // Worst-case size for output is zero compression on the input, meaning the input size plus the number of layout bytes plus the Yaz0 header.
     // There would be one layout byte for every 8 input bytes, so the worst-case size is:
     //   input_size + ROUND_UP_DIVIDE(input_size, 8) + 0x10
-    Ok(input_size + divide_round_up(input_size, 8) + 0x10)
+    Ok(input_size + input_size.div_ceil(8) + 0x10)
 }
 
 pub fn compress(bytes: &[u8]) -> Result<Box<[u8]>, Crunch64Error> {

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,3 @@
+[mypy]
+python_version = 3.9
+check_untyped_defs = True


### PR DESCRIPTION
- Bump crunch64's version to 0.5.2
- Add prebuilt binaries for Python 3.13.
- Set new min Python version to 3.9 since we can't build older wheels with CI anymore.
- Set MSRV (minimum supported Rust version).
- Fix new clippy complains.
