### PR TITLE
Fix macos x86 wheels

### DIFF
--- a/.github/workflows/maturin_upload_pypi.yml
+++ b/.github/workflows/maturin_upload_pypi.yml
@@ -141,7 +141,7 @@ jobs:
     strategy:
       matrix:
         platform:
-          - runner: macos-13
+          - runner: macos-15-intel
             target: x86_64
           - runner: macos-14
             target: aarch64

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.6.0] - 2025-10-11
+## [0.6.0] - 2026-12-01
 
 ### Added
 
@@ -22,6 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - CI allows us to build for 3.8 again.
 - Change the hard requirement of Python 3.9 to just Python 3 in the package metadata.
   - Note there's no official support for Python versions older than 3.8.
+
+### Fixed
+
+- Since `macos-13` is no longer a valid CI runner, we now use `macos-15-intel` to build MacOS Python wheels.
 
 ## [0.5.4] - 2024-12-15
 
@@ -118,7 +122,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - C bindings.
 
 [unreleased]: https://github.com/decompals/crunch64/compare/0.6.0...HEAD
-[0.6.0]: https://github.com/decompals/crunch64/compare/0.5.3...0.6.0
+[0.6.0]: https://github.com/decompals/crunch64/compare/0.5.4...0.6.0
+[0.5.4]: https://github.com/decompals/crunch64/compare/0.5.3...0.5.4
 [0.5.3]: https://github.com/decompals/crunch64/compare/0.5.2...0.5.3
 [0.5.2]: https://github.com/decompals/crunch64/compare/0.5.1...0.5.2
 [0.5.1]: https://github.com/decompals/crunch64/compare/0.5.0...0.5.1


### PR DESCRIPTION
`macos-13` is no longer a valid CI runner, so this PR changes it to `macos-15-intel`.