### PR TITLE
Fix CI not running Rust tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,26 +28,26 @@ jobs:
           cargo clippy --version
           cargo clippy --all --all-targets --all-features -- -D warnings
 
-  macos-check:
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v5
-      - name: Test
-        run: cargo test
+  test:
+    name: Test on ${{ matrix.platform.name }}
+    runs-on: ${{ matrix.platform.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - name: linux
+            runner: ubuntu-latest
+          - name: macos
+            runner: macos-latest
+          - name: windows
+            runner: windows-latest
 
-  ubuntu-check:
-    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - name: Test
-        run: cargo test
+      - name: Checkout reposistory
+        uses: actions/checkout@v6
 
-  windows-check:
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v5
       - name: Test
-        run: cargo test
+        run: cargo test -F std
 
   msrv:
     name: Check MSRV

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix CI not running Rust tests.
+
 ## [0.6.1] - 2026-01-11
 
 ### Added


### PR DESCRIPTION
This happened because the tests are now guarded under the `std` feature, but we were not passing that feature to the CI command