### PR TITLE
Test the built C library in CI

### DIFF
--- a/.github/workflows/c_bindings.yml
+++ b/.github/workflows/c_bindings.yml
@@ -22,14 +22,14 @@ jobs:
 
   release:
     name: Release ${{ matrix.crate-type }} for ${{ matrix.target }}
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.platform.runner }}
     strategy:
       fail-fast: false
       matrix:
         target:
           - x86_64-pc-windows-gnu
           - x86_64-pc-windows-msvc
-          - x86_64-pc-windows-msvc
+          - aarch64-pc-windows-msvc
           - x86_64-apple-darwin
           - aarch64-apple-darwin
           - x86_64-unknown-linux-musl
@@ -41,27 +41,35 @@ jobs:
           - target: x86_64-pc-windows-gnu
             archive: zip
             target_group: unix
+            runner: windows-latest
           - target: x86_64-pc-windows-msvc
             archive: zip
             target_group: windows
+            runner: windows-latest
           - target: aarch64-pc-windows-msvc
             archive: zip
             target_group: windows
+            runner: windows-latest
           - target: x86_64-apple-darwin
             archive: zip
             target_group: unix
+            runner: macos-15-intel
           - target: aarch64-apple-darwin
             archive: zip
             target_group: unix
+            runner: macos-latest
           - target: x86_64-unknown-linux-musl
             archive: tar.gz
             target_group: unix
+            runner: ubuntu-22.04
           - target: x86_64-unknown-linux-gnu
             archive: tar.gz
             target_group: unix
+            runner: ubuntu-22.04
           - target: aarch64-unknown-linux-gnu
             archive: tar.gz
             target_group: unix
+            runner: ubuntu-22.04
 
     steps:
       - name: Checkout repo

--- a/.github/workflows/c_bindings.yml
+++ b/.github/workflows/c_bindings.yml
@@ -42,33 +42,41 @@ jobs:
             archive: zip
             os_name: windows
             runner: windows-latest
+            architecture: x86
           - target: x86_64-pc-windows-msvc
             archive: zip
             os_name: windows
             runner: windows-latest
+            architecture: x86
           - target: aarch64-pc-windows-msvc
             archive: zip
             os_name: windows
             runner: windows-latest
+            architecture: aarch64
           - target: x86_64-apple-darwin
             archive: zip
             os_name: macos
             runner: macos-15-intel
+            architecture: x86
           - target: aarch64-apple-darwin
             archive: zip
             os_name: macos
             runner: macos-latest
+            architecture: aarch64
           - target: x86_64-unknown-linux-musl
             archive: tar.gz
             os_name: linux
             runner: ubuntu-22.04
+            architecture: x86
           - target: x86_64-unknown-linux-gnu
             archive: tar.gz
             os_name: linux
             runner: ubuntu-22.04
+            architecture: x86
           - target: aarch64-unknown-linux-gnu
             archive: tar.gz
             os_name: linux
+            architecture: aarch64
             runner: ubuntu-22.04
 
     steps:
@@ -94,7 +102,9 @@ jobs:
 
       - name: Move files for packaging
         run: |
-          mkdir package package/lib package/include
+          mkdir package
+          mkdir package/lib
+          mkdir package/include
           cp target/${{ matrix.target }}/release/libcrunch64.a package/lib/ || cp target/${{ matrix.target }}/release/crunch64.lib package/lib/
           cp -r c_bindings/include/* package/include/
           cp LICENSE package/crunch64.LICENSEzip
@@ -119,11 +129,26 @@ jobs:
             crunch64-${{ matrix.crate-type }}-${{ matrix.target }}.${{ matrix.archive }}
           if-no-files-found: error
 
-      # - name: Test built archive
-      #   if: matrix.target_group == 'unix'
-      #   run: |
-      #     cc -I c_bindings/include/ c_bindings/tests.c -L package/lib/ -l crunch64 -o tests.elf
-      #     ./tests.elf
+      - name: Test built archive (x86, unix like)
+        if: (matrix.os_name == 'linux' && matrix.architecture == 'x86') || matrix.os_name == 'macos' || matrix.target == 'x86_64-pc-windows-gnu'
+        run: |
+          cc -I c_bindings/include/ c_bindings/tests.c -L package/lib/ -l crunch64 -o tests.elf
+          ./tests.elf
+
+      - name: Test built archive (aarch64 linux)
+        if: matrix.os_name == 'linux' && matrix.architecture == 'aarch64'
+        run: |
+          docker run --platform linux/arm64 --rm -v ${{ github.workspace }}:/work -w /work gcc:latest \
+          cc -I c_bindings/include/ c_bindings/tests.c -L package/lib/ -l crunch64 -o tests.elf \
+          ./tests.elf
+
+      - name: Test built archive (x86 msvc)
+        if: (matrix.os_name == 'windows' && matrix.architecture == 'x86') && matrix.target != 'x86_64-pc-windows-gnu'
+        run: |
+          cl /I c_bindings/include/ c_bindings/tests.c package/lib/crunch64.lib /Fe:tests.exe
+          tests.exe
+
+      # We don't have a way to build and run aarch64 windows binaries on GHA :c
 
       - name: Publish ${{ matrix.archive }} release
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/c_bindings.yml
+++ b/.github/workflows/c_bindings.yml
@@ -138,7 +138,12 @@ jobs:
           cd package && tar -czf ../crunch64-${{ matrix.crate-type }}-${{ matrix.target }}.tar.gz *
 
       - name: Package .zip
-        if: matrix.archive == 'zip'
+        if: matrix.archive == 'zip' && matrix.os_name == 'macos'
+        run: |
+          cd package && zip -r ../crunch64-${{ matrix.crate-type }}-${{ matrix.target }}.zip *
+
+      - name: Package .zip
+        if: matrix.archive == 'zip' && matrix.os_name == 'windows'
         run: |
           cd package; Compress-Archive -Path * -DestinationPath ../crunch64-${{ matrix.crate-type }}-${{ matrix.target }}.zip
 
@@ -159,7 +164,7 @@ jobs:
           ./tests.elf
 
       - name: Setup qemu
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
         if: matrix.os_name == 'linux' && matrix.architecture == 'aarch64'
 
       - name: Test built archive (aarch64 linux)

--- a/.github/workflows/c_bindings.yml
+++ b/.github/workflows/c_bindings.yml
@@ -34,6 +34,7 @@ jobs:
           - aarch64-apple-darwin
           - x86_64-unknown-linux-musl
           - x86_64-unknown-linux-gnu
+          - aarch64-unknown-linux-musl
           - aarch64-unknown-linux-gnu
         crate-type:
           - staticlib
@@ -66,13 +67,18 @@ jobs:
           - target: x86_64-unknown-linux-musl
             archive: tar.gz
             os_name: linux
-            runner: ubuntu-24.04
+            runner: ubuntu-22.04
             architecture: x86
           - target: x86_64-unknown-linux-gnu
             archive: tar.gz
             os_name: linux
             runner: ubuntu-22.04
             architecture: x86
+          - target: aarch64-unknown-linux-musl
+            archive: tar.gz
+            os_name: linux
+            architecture: aarch64
+            runner: ubuntu-22.04
           - target: aarch64-unknown-linux-gnu
             archive: tar.gz
             os_name: linux
@@ -172,11 +178,17 @@ jobs:
       - name: Setup qemu
         uses: docker/setup-qemu-action@v4
         if: matrix.os_name == 'linux' && matrix.architecture == 'aarch64'
-      - name: Test built archive (aarch64 linux)
+      - name: Test built archive (aarch64, linux)
         if: matrix.os_name == 'linux' && matrix.architecture == 'aarch64'
         run: |
           docker run --platform linux/arm64 --rm -v ${{ github.workspace }}:/work -w /work gcc:latest \
           sh -c "cc -I c_bindings/include/ c_bindings/tests.c -L package/lib/ -l crunch64 -o tests.elf && ./tests.elf"
+      # Full static binary
+      - name: Test built archive (aarch64, linux, musl, clang)
+        if: matrix.os_name == 'linux' && matrix.architecture == 'aarch64' && matrix.target == 'aarch64-unknown-linux-musl'
+        run: |
+          docker run --platform linux/arm64 --rm -v ${{ github.workspace }}:/work -w /work gcc:latest \
+          sh -c "clang -fuse-ld=lld -I/usr/include/aarch64-linux-musl -L/usr/lib/aarch64-linux-musl --target=aarch64-unknown-linux-musl -static -Wl,--gc-sections -Wl,--strip-all -ffunction-sections -fdata-sections -I c_bindings/include/ c_bindings/tests.c -L package/lib/ -l crunch64 -o tests.elf && ./tests.elf"
 
       - name: Setup MSVC in PATH
         uses: ilammy/msvc-dev-cmd@v1

--- a/.github/workflows/c_bindings.yml
+++ b/.github/workflows/c_bindings.yml
@@ -188,7 +188,7 @@ jobs:
         if: matrix.os_name == 'linux' && matrix.architecture == 'aarch64' && matrix.target == 'aarch64-unknown-linux-musl'
         run: |
           docker run --platform linux/arm64 --rm -v ${{ github.workspace }}:/work -w /work alpine:latest \
-          sh -c "clang -fuse-ld=lld -I/usr/include/aarch64-linux-musl -L/usr/lib/aarch64-linux-musl --target=aarch64-unknown-linux-musl -static -Wl,--gc-sections -Wl,--strip-all -ffunction-sections -fdata-sections -I c_bindings/include/ c_bindings/tests.c -L package/lib/ -l crunch64 -o tests.elf && ./tests.elf"
+          sh -c "apk add -y clang lld && clang -fuse-ld=lld -I/usr/include/aarch64-linux-musl -L/usr/lib/aarch64-linux-musl --target=aarch64-unknown-linux-musl -static -Wl,--gc-sections -Wl,--strip-all -ffunction-sections -fdata-sections -I c_bindings/include/ c_bindings/tests.c -L package/lib/ -l crunch64 -o tests.elf && ./tests.elf"
 
       - name: Setup MSVC in PATH
         uses: ilammy/msvc-dev-cmd@v1

--- a/.github/workflows/c_bindings.yml
+++ b/.github/workflows/c_bindings.yml
@@ -40,35 +40,35 @@ jobs:
         include:
           - target: x86_64-pc-windows-gnu
             archive: zip
-            target_group: unix
+            os_name: windows
             runner: windows-latest
           - target: x86_64-pc-windows-msvc
             archive: zip
-            target_group: windows
+            os_name: windows
             runner: windows-latest
           - target: aarch64-pc-windows-msvc
             archive: zip
-            target_group: windows
+            os_name: windows
             runner: windows-latest
           - target: x86_64-apple-darwin
             archive: zip
-            target_group: unix
+            os_name: macos
             runner: macos-15-intel
           - target: aarch64-apple-darwin
             archive: zip
-            target_group: unix
+            os_name: macos
             runner: macos-latest
           - target: x86_64-unknown-linux-musl
             archive: tar.gz
-            target_group: unix
+            os_name: linux
             runner: ubuntu-22.04
           - target: x86_64-unknown-linux-gnu
             archive: tar.gz
-            target_group: unix
+            os_name: linux
             runner: ubuntu-22.04
           - target: aarch64-unknown-linux-gnu
             archive: tar.gz
-            target_group: unix
+            os_name: linux
             runner: ubuntu-22.04
 
     steps:
@@ -83,13 +83,18 @@ jobs:
       - name: Build lib
         run: cargo rustc --manifest-path lib/Cargo.toml --lib --features c_bindings --release --crate-type ${{ matrix.crate-type }} --target ${{ matrix.target }}
 
+      - name: Install tree
+        if: matrix.os_name == 'macos'
+        run:
+          brew install tree
+
       - name: Print built files
         run: |
           tree target/${{ matrix.target }}/release
 
       - name: Move files for packaging
         run: |
-          mkdir -p package/lib package/include
+          mkdir package package/lib package/include
           cp target/${{ matrix.target }}/release/libcrunch64.a package/lib/ || cp target/${{ matrix.target }}/release/crunch64.lib package/lib/
           cp -r c_bindings/include/* package/include/
           cp LICENSE package/crunch64.LICENSEzip
@@ -114,11 +119,11 @@ jobs:
             crunch64-${{ matrix.crate-type }}-${{ matrix.target }}.${{ matrix.archive }}
           if-no-files-found: error
 
-      - name: Test built archive
-        if: matrix.target_group == 'unix'
-        run: |
-          cc -I c_bindings/include/ c_bindings/tests.c -L package/lib/ -l crunch64 -o tests.elf
-          ./tests.elf
+      # - name: Test built archive
+      #   if: matrix.target_group == 'unix'
+      #   run: |
+      #     cc -I c_bindings/include/ c_bindings/tests.c -L package/lib/ -l crunch64 -o tests.elf
+      #     ./tests.elf
 
       - name: Publish ${{ matrix.archive }} release
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/c_bindings.yml
+++ b/.github/workflows/c_bindings.yml
@@ -115,16 +115,17 @@ jobs:
           cp -r c_bindings/include/* package/include/
           cp LICENSE package/crunch64.LICENSEzip
           cp README.md package/crunch64.README.md
-          cp target/${{ matrix.target }}/release/crunch64.lib package/lib/ || cp target/${{ matrix.target }}/release/libcrunch64.a package/lib/
 
-      - name: Print package (unix)
-        if: matrix.os_name == 'linux' || matrix.os_name == 'macos'
+      - name: Copy package (unix)
+        if: matrix.os_name == 'linux' || matrix.os_name == 'macos' || matrix.target == 'x86_64-pc-windows-gnu'
         run: |
+          cp target/${{ matrix.target }}/release/libcrunch64.a package/lib/
           tree package
 
-      - name: Print package (windows)
-        if: matrix.os_name == 'windows'
+      - name: Copy package (windows)
+        if: matrix.os_name == 'windows' && matrix.target != 'x86_64-pc-windows-gnu'
         run: |
+          cp target/${{ matrix.target }}/release/crunch64.lib package/lib/
           tree /f package
 
       # Compress the package files

--- a/.github/workflows/c_bindings.yml
+++ b/.github/workflows/c_bindings.yml
@@ -161,6 +161,15 @@ jobs:
           cc -I c_bindings/include/ c_bindings/tests.c -L package/lib/ -l crunch64 -o tests.elf
           ./tests.elf
 
+      # Full static binary
+      - name: Test built archive (x86, unix like, musl, clang)
+        if: matrix.target == 'x86_64-unknown-linux-musl'
+        run: |
+          clang -fuse-ld=lld -I/usr/include/x86_64-linux-musl -L/usr/lib/x86_64-linux-musl --target=x86_64-unknown-linux-musl -static -Wl,--gc-sections -Wl,--strip-all -ffunction-sections -fdata-sections -I c_bindings/include/ c_bindings/tests.c -L package/lib/ -l crunch64 -o tests.elf
+          file ./tests.elf
+          ldd ./tests.elf
+          ./tests.elf
+
       - name: Setup qemu
         uses: docker/setup-qemu-action@v4
         if: matrix.os_name == 'linux' && matrix.architecture == 'aarch64'
@@ -181,7 +190,7 @@ jobs:
           ./tests.exe
 
       # Windows needs extra flags
-      - name: Test built archive (x86, unix like)
+      - name: Test built archive (x86 windows, unix like)
         if: matrix.target == 'x86_64-pc-windows-gnu'
         run: |
           cc -I c_bindings/include/ c_bindings/tests.c -L package/lib/ -l crunch64 -lws2_32 -lntdll -lbcrypt -ladvapi32 -luserenv -o tests.exe

--- a/.github/workflows/c_bindings.yml
+++ b/.github/workflows/c_bindings.yml
@@ -188,7 +188,7 @@ jobs:
         if: matrix.os_name == 'linux' && matrix.architecture == 'aarch64' && matrix.target == 'aarch64-unknown-linux-musl'
         run: |
           docker run --platform linux/arm64 --rm -v ${{ github.workspace }}:/work -w /work alpine:latest \
-          sh -c "apk add -y clang lld && clang -fuse-ld=lld -I/usr/include/aarch64-linux-musl -L/usr/lib/aarch64-linux-musl --target=aarch64-unknown-linux-musl -static -Wl,--gc-sections -Wl,--strip-all -ffunction-sections -fdata-sections -I c_bindings/include/ c_bindings/tests.c -L package/lib/ -l crunch64 -o tests.elf && ./tests.elf"
+          sh -c "apk add clang lld && clang -fuse-ld=lld -I/usr/include/aarch64-linux-musl -L/usr/lib/aarch64-linux-musl --target=aarch64-unknown-linux-musl -static -Wl,--gc-sections -Wl,--strip-all -ffunction-sections -fdata-sections -I c_bindings/include/ c_bindings/tests.c -L package/lib/ -l crunch64 -o tests.elf && ./tests.elf"
 
       - name: Setup MSVC in PATH
         uses: ilammy/msvc-dev-cmd@v1

--- a/.github/workflows/c_bindings.yml
+++ b/.github/workflows/c_bindings.yml
@@ -22,7 +22,7 @@ jobs:
 
   release:
     name: Release ${{ matrix.crate-type }} for ${{ matrix.target }}
-    runs-on: ${{ matrix.platform.runner }}
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/c_bindings.yml
+++ b/.github/workflows/c_bindings.yml
@@ -119,7 +119,7 @@ jobs:
           mkdir package/lib
           mkdir package/include
           cp -r c_bindings/include/* package/include/
-          cp LICENSE package/crunch64.LICENSEzip
+          cp LICENSE package/crunch64.LICENSE
           cp README.md package/crunch64.README.md
 
       - name: Copy package (unix)
@@ -151,7 +151,7 @@ jobs:
         run: |
           cd package; Compress-Archive -Path * -DestinationPath ../crunch64-${{ matrix.crate-type }}-${{ matrix.target }}.zip
 
-      # Upload the artifact, useful for inspecting the artifacts
+      # Upload the artifact, useful for inspecting everything is ok
       - name: Upload ${{ matrix.archive }} archive
         uses: actions/upload-artifact@main
         with:
@@ -187,7 +187,7 @@ jobs:
       - name: Test built archive (aarch64, linux, musl, clang)
         if: matrix.os_name == 'linux' && matrix.architecture == 'aarch64' && matrix.target == 'aarch64-unknown-linux-musl'
         run: |
-          docker run --platform linux/arm64 --rm -v ${{ github.workspace }}:/work -w /work gcc:latest \
+          docker run --platform linux/arm64 --rm -v ${{ github.workspace }}:/work -w /work alpine:latest \
           sh -c "clang -fuse-ld=lld -I/usr/include/aarch64-linux-musl -L/usr/lib/aarch64-linux-musl --target=aarch64-unknown-linux-musl -static -Wl,--gc-sections -Wl,--strip-all -ffunction-sections -fdata-sections -I c_bindings/include/ c_bindings/tests.c -L package/lib/ -l crunch64 -o tests.elf && ./tests.elf"
 
       - name: Setup MSVC in PATH

--- a/.github/workflows/c_bindings.yml
+++ b/.github/workflows/c_bindings.yml
@@ -96,17 +96,17 @@ jobs:
         run:
           brew install tree
 
-      - name: Print built files
+      - name: Print built files (unix)
         if: matrix.os_name == 'linux' || matrix.os_name == 'macos'
         run: |
           tree target/${{ matrix.target }}/release
 
-      - name: Print built files
+      - name: Print built files (windows)
         if: matrix.os_name == 'windows'
         run: |
           tree /f target/${{ matrix.target }}/release
 
-      # Move versioned files to a new folder, this will contain the final release files
+      # Move versioned files and built lib to a new folder, this will contain the final release files
       - name: Move files for packaging
         run: |
           mkdir package
@@ -115,19 +115,16 @@ jobs:
           cp -r c_bindings/include/* package/include/
           cp LICENSE package/crunch64.LICENSEzip
           cp README.md package/crunch64.README.md
+          cp target/${{ matrix.target }}/release/crunch64.lib package/lib/ || cp target/${{ matrix.target }}/release/libcrunch64.a package/lib/
 
-      # Move the built library.
-      # This is a two step thing because windows is silly.
-      - name: Move lib for packaging (unix)
+      - name: Print package (unix)
         if: matrix.os_name == 'linux' || matrix.os_name == 'macos'
         run: |
-          cp target/${{ matrix.target }}/release/libcrunch64.a package/lib/
           tree package
 
-      - name: Move lib for packaging (windows)
+      - name: Print package (windows)
         if: matrix.os_name == 'windows'
         run: |
-          cp target/${{ matrix.target }}/release/crunch64.lib package/lib/
           tree /f package
 
       # Compress the package files
@@ -166,13 +163,15 @@ jobs:
       - name: Setup qemu
         uses: docker/setup-qemu-action@v4
         if: matrix.os_name == 'linux' && matrix.architecture == 'aarch64'
-
       - name: Test built archive (aarch64 linux)
         if: matrix.os_name == 'linux' && matrix.architecture == 'aarch64'
         run: |
           docker run --platform linux/arm64 --rm -v ${{ github.workspace }}:/work -w /work gcc:latest \
           sh -c "cc -I c_bindings/include/ c_bindings/tests.c -L package/lib/ -l crunch64 -o tests.elf && ./tests.elf"
 
+      - name: Setup MSVC in PATH
+        uses: ilammy/msvc-dev-cmd@v1
+        if: (matrix.os_name == 'windows' && matrix.architecture == 'x86') && matrix.target != 'x86_64-pc-windows-gnu'
       - name: Test built archive (x86 msvc)
         if: (matrix.os_name == 'windows' && matrix.architecture == 'x86') && matrix.target != 'x86_64-pc-windows-gnu'
         run: |

--- a/.github/workflows/c_bindings.yml
+++ b/.github/workflows/c_bindings.yml
@@ -105,10 +105,22 @@ jobs:
           mkdir package
           mkdir package/lib
           mkdir package/include
-          cp target/${{ matrix.target }}/release/libcrunch64.a package/lib/ || cp target/${{ matrix.target }}/release/crunch64.lib package/lib/
           cp -r c_bindings/include/* package/include/
           cp LICENSE package/crunch64.LICENSEzip
           cp README.md package/crunch64.README.md
+
+      - name: Move lib for packaging (unix)
+        if: matrix.os_name == 'linux' || matrix.os_name == 'macos'
+        run: |
+          cp target/${{ matrix.target }}/release/libcrunch64.a package/lib/
+
+      - name: Move lib for packaging (windows)
+        if: matrix.os_name == 'windows'
+        run: |
+          cp target/${{ matrix.target }}/release/crunch64.lib package/lib/
+
+      - name: Print package files
+        run: |
           tree package
 
       - name: Package .tar.gz
@@ -135,12 +147,15 @@ jobs:
           cc -I c_bindings/include/ c_bindings/tests.c -L package/lib/ -l crunch64 -o tests.elf
           ./tests.elf
 
+      - name: Setup qemu
+        uses: docker/setup-qemu-action@v3
+        if: matrix.os_name == 'linux' && matrix.architecture == 'aarch64'
+
       - name: Test built archive (aarch64 linux)
         if: matrix.os_name == 'linux' && matrix.architecture == 'aarch64'
         run: |
           docker run --platform linux/arm64 --rm -v ${{ github.workspace }}:/work -w /work gcc:latest \
-          cc -I c_bindings/include/ c_bindings/tests.c -L package/lib/ -l crunch64 -o tests.elf \
-          ./tests.elf
+          sh -c "cc -I c_bindings/include/ c_bindings/tests.c -L package/lib/ -l crunch64 -o tests.elf && ./tests.elf"
 
       - name: Test built archive (x86 msvc)
         if: (matrix.os_name == 'windows' && matrix.architecture == 'x86') && matrix.target != 'x86_64-pc-windows-gnu'

--- a/.github/workflows/c_bindings.yml
+++ b/.github/workflows/c_bindings.yml
@@ -9,12 +9,10 @@ jobs:
   test-c-bindings:
     name: Test C bindings
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@main
 
       - name: Make C test program
         run: make -C c_bindings BUILD_MODE=release
@@ -28,23 +26,46 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [x86_64-pc-windows-gnu, x86_64-pc-windows-msvc, x86_64-apple-darwin, x86_64-unknown-linux-musl, x86_64-unknown-linux-gnu]
-        crate-type: [staticlib]
+        target:
+          - x86_64-pc-windows-gnu
+          - x86_64-pc-windows-msvc
+          - x86_64-pc-windows-msvc
+          - x86_64-apple-darwin
+          - aarch64-apple-darwin
+          - x86_64-unknown-linux-musl
+          - x86_64-unknown-linux-gnu
+          - aarch64-unknown-linux-gnu
+        crate-type:
+          - staticlib
         include:
           - target: x86_64-pc-windows-gnu
             archive: zip
+            target_group: unix
           - target: x86_64-pc-windows-msvc
             archive: zip
+            target_group: windows
+          - target: aarch64-pc-windows-msvc
+            archive: zip
+            target_group: windows
           - target: x86_64-apple-darwin
             archive: zip
+            target_group: unix
+          - target: aarch64-apple-darwin
+            archive: zip
+            target_group: unix
           - target: x86_64-unknown-linux-musl
             archive: tar.gz
+            target_group: unix
           - target: x86_64-unknown-linux-gnu
             archive: tar.gz
+            target_group: unix
+          - target: aarch64-unknown-linux-gnu
+            archive: tar.gz
+            target_group: unix
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@main
 
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -63,7 +84,7 @@ jobs:
           mkdir -p package/lib package/include
           cp target/${{ matrix.target }}/release/libcrunch64.a package/lib/ || cp target/${{ matrix.target }}/release/crunch64.lib package/lib/
           cp -r c_bindings/include/* package/include/
-          cp LICENSE package/crunch64.LICENSE
+          cp LICENSE package/crunch64.LICENSEzip
           cp README.md package/crunch64.README.md
           tree package
 
@@ -77,32 +98,22 @@ jobs:
         run: |
           cd package && zip -r ../crunch64-${{ matrix.crate-type }}-${{ matrix.target }}.zip *
 
-      - name: Upload .tar.gz archive
-        if: matrix.archive == 'tar.gz'
-        uses: actions/upload-artifact@v4
+      - name: Upload ${{ matrix.archive }} archive
+        uses: actions/upload-artifact@main
         with:
           name: crunch64-${{ matrix.crate-type }}-${{ matrix.target }}
           path: |
-            crunch64-${{ matrix.crate-type }}-${{ matrix.target }}.tar.gz
+            crunch64-${{ matrix.crate-type }}-${{ matrix.target }}.${{ matrix.archive }}
           if-no-files-found: error
 
-      - name: Upload .zip archive
-        if: matrix.archive == 'zip'
-        uses: actions/upload-artifact@v4
-        with:
-          name: crunch64-${{ matrix.crate-type }}-${{ matrix.target }}
-          path: |
-            crunch64-${{ matrix.crate-type }}-${{ matrix.target }}.zip
-          if-no-files-found: error
+      - name: Test built archive
+        if: matrix.target_group == 'unix'
+        run: |
+          cc -I c_bindings/include/ c_bindings/tests.c -L package/lib/ -l crunch64 -o tests.elf
+          ./tests.elf
 
-      - name: Publish .tar.gz release
+      - name: Publish ${{ matrix.archive }} release
         uses: softprops/action-gh-release@v1
-        if: startsWith(github.ref, 'refs/tags/') && matrix.archive == 'tar.gz'
+        if: startsWith(github.ref, 'refs/tags/')
         with:
-          files: crunch64-${{ matrix.crate-type }}-${{ matrix.target }}.tar.gz
-
-      - name: Publish .zip release
-        uses: softprops/action-gh-release@v1
-        if: startsWith(github.ref, 'refs/tags/') && matrix.archive == 'zip'
-        with:
-          files: crunch64-${{ matrix.crate-type }}-${{ matrix.target }}.zip
+          files: crunch64-${{ matrix.crate-type }}-${{ matrix.target }}.${{ matrix.archive }}

--- a/.github/workflows/c_bindings.yml
+++ b/.github/workflows/c_bindings.yml
@@ -173,11 +173,19 @@ jobs:
       - name: Setup MSVC in PATH
         uses: ilammy/msvc-dev-cmd@v1
         if: (matrix.os_name == 'windows' && matrix.architecture == 'x86') && matrix.target != 'x86_64-pc-windows-gnu'
+      # Windows needs extra flags
       - name: Test built archive (x86 msvc)
         if: (matrix.os_name == 'windows' && matrix.architecture == 'x86') && matrix.target != 'x86_64-pc-windows-gnu'
         run: |
-          cl /I c_bindings/include/ c_bindings/tests.c package/lib/crunch64.lib /Fe:tests.exe
-          tests.exe
+          cl /I c_bindings/include/ c_bindings/tests.c package/lib/crunch64.lib ws2_32.lib ntdll.lib bcrypt.lib advapi32.lib userenv.lib  /Fe:tests.exe
+          ./tests.exe
+
+      # Windows needs extra flags
+      - name: Test built archive (x86, unix like)
+        if: matrix.target == 'x86_64-pc-windows-gnu'
+        run: |
+          cc -I c_bindings/include/ c_bindings/tests.c -L package/lib/ -l crunch64 -lws2_32 -lntdll -lbcrypt -ladvapi32 -luserenv -o tests.exe
+          ./tests.exe
 
       # We don't have a way to build and run aarch64 windows binaries on GHA :c
 

--- a/.github/workflows/c_bindings.yml
+++ b/.github/workflows/c_bindings.yml
@@ -97,9 +97,16 @@ jobs:
           brew install tree
 
       - name: Print built files
+        if: matrix.os_name == 'linux' || matrix.os_name == 'macos'
         run: |
           tree target/${{ matrix.target }}/release
 
+      - name: Print built files
+        if: matrix.os_name == 'windows'
+        run: |
+          tree /f target/${{ matrix.target }}/release
+
+      # Move versioned files to a new folder, this will contain the final release files
       - name: Move files for packaging
         run: |
           mkdir package
@@ -109,20 +116,22 @@ jobs:
           cp LICENSE package/crunch64.LICENSEzip
           cp README.md package/crunch64.README.md
 
+      # Move the built library.
+      # This is a two step thing because windows is silly.
       - name: Move lib for packaging (unix)
         if: matrix.os_name == 'linux' || matrix.os_name == 'macos'
         run: |
           cp target/${{ matrix.target }}/release/libcrunch64.a package/lib/
+          tree package
 
       - name: Move lib for packaging (windows)
         if: matrix.os_name == 'windows'
         run: |
           cp target/${{ matrix.target }}/release/crunch64.lib package/lib/
+          tree /f package
 
-      - name: Print package files
-        run: |
-          tree package
-
+      # Compress the package files
+      # Two steps because windows silly
       - name: Package .tar.gz
         if: matrix.archive == 'tar.gz'
         run: |
@@ -131,8 +140,9 @@ jobs:
       - name: Package .zip
         if: matrix.archive == 'zip'
         run: |
-          cd package && zip -r ../crunch64-${{ matrix.crate-type }}-${{ matrix.target }}.zip *
+          cd package; Compress-Archive -Path * -DestinationPath ../crunch64-${{ matrix.crate-type }}-${{ matrix.target }}.zip
 
+      # Upload the artifact, useful for inspecting the artifacts
       - name: Upload ${{ matrix.archive }} archive
         uses: actions/upload-artifact@main
         with:
@@ -141,6 +151,7 @@ jobs:
             crunch64-${{ matrix.crate-type }}-${{ matrix.target }}.${{ matrix.archive }}
           if-no-files-found: error
 
+      # Build and run the archives. Multi step because each os/arch combo is weird
       - name: Test built archive (x86, unix like)
         if: (matrix.os_name == 'linux' && matrix.architecture == 'x86') || matrix.os_name == 'macos' || matrix.target == 'x86_64-pc-windows-gnu'
         run: |
@@ -165,6 +176,7 @@ jobs:
 
       # We don't have a way to build and run aarch64 windows binaries on GHA :c
 
+      # Actually publish the built files to github releases
       - name: Publish ${{ matrix.archive }} release
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/c_bindings.yml
+++ b/.github/workflows/c_bindings.yml
@@ -66,7 +66,7 @@ jobs:
           - target: x86_64-unknown-linux-musl
             archive: tar.gz
             os_name: linux
-            runner: ubuntu-22.04
+            runner: ubuntu-24.04
             architecture: x86
           - target: x86_64-unknown-linux-gnu
             archive: tar.gz
@@ -167,7 +167,6 @@ jobs:
         run: |
           clang -fuse-ld=lld -I/usr/include/x86_64-linux-musl -L/usr/lib/x86_64-linux-musl --target=x86_64-unknown-linux-musl -static -Wl,--gc-sections -Wl,--strip-all -ffunction-sections -fdata-sections -I c_bindings/include/ c_bindings/tests.c -L package/lib/ -l crunch64 -o tests.elf
           file ./tests.elf
-          ldd ./tests.elf
           ./tests.elf
 
       - name: Setup qemu

--- a/.github/workflows/c_bindings.yml
+++ b/.github/workflows/c_bindings.yml
@@ -156,7 +156,7 @@ jobs:
 
       # Build and run the archives. Multi step because each os/arch combo is weird
       - name: Test built archive (x86, unix like)
-        if: (matrix.os_name == 'linux' && matrix.architecture == 'x86') || matrix.os_name == 'macos' || matrix.target == 'x86_64-pc-windows-gnu'
+        if: (matrix.os_name == 'linux' && matrix.architecture == 'x86') || matrix.os_name == 'macos'
         run: |
           cc -I c_bindings/include/ c_bindings/tests.c -L package/lib/ -l crunch64 -o tests.elf
           ./tests.elf

--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,7 @@ target/
 *.Yay0
 *.Yaz0
 *.elf
+*.a
+*.lib
 
 .vscode/settings.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.2] - 2026-03-28
+
+### Added
+
+- Prebuilt C archive libraries for the following targets:
+  - `aarch64-pc-windows-msvc`
+  - `aarch64-apple-darwin`
+  - `aarch64-unknown-linux-gnu`
+  - `aarch64-unknown-linux-musl`
+- Most prebuilt C libs are now tested in CI.
+  - The following targets are being tested in CI:
+    - `x86_64-pc-windows-gnu`
+    - `x86_64-pc-windows-msvc`
+    - `x86_64-apple-darwin`
+    - `aarch64-apple-darwin`
+    - `x86_64-unknown-linux-musl`
+      - Builds/links using GCC default and Clang with musl target.
+    - `x86_64-unknown-linux-gnu`
+    - `aarch64-unknown-linux-musl`
+    - `aarch64-unknown-linux-gnu`
+  - The following targets are NOT being tested in CI:
+    - `aarch64-pc-windows-msvc`
+
+### Changed
+
+- Prebuilt C libs are now built under the corresponding native OS instead of
+  crosscompiling from an Ubuntu runner.
+- Rewrite the C bindings test file to make it compatible with MSVC.
+
 ### Fixed
 
 - Fix CI not running Rust tests.
@@ -139,7 +168,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Python bindings.
 - C bindings.
 
-[unreleased]: https://github.com/decompals/crunch64/compare/0.6.1...HEAD
+[unreleased]: https://github.com/decompals/crunch64/compare/0.6.2...HEAD
+[0.6.2]: https://github.com/decompals/crunch64/compare/0.6.1...0.6.2
 [0.6.1]: https://github.com/decompals/crunch64/compare/0.6.0...0.6.1
 [0.6.0]: https://github.com/decompals/crunch64/compare/0.5.4...0.6.0
 [0.5.4]: https://github.com/decompals/crunch64/compare/0.5.3...0.5.4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,7 +130,7 @@ dependencies = [
 
 [[package]]
 name = "crunch64"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "crc32fast",
  "pyo3",
@@ -140,7 +140,7 @@ dependencies = [
 
 [[package]]
 name = "crunch64-cli"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "clap",
  "crunch64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [workspace.package]
 # Version should be synced with lib/pyproject.toml and lib/crunch64/__init__.py
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 repository = "https://github.com/decompals/crunch64"
 license = "MIT"

--- a/c_bindings/tests.c
+++ b/c_bindings/tests.c
@@ -1,12 +1,84 @@
 #include "crunch64.h"
 
 #include <assert.h>
-#include <dirent.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
+#ifdef _MSC_VER
+#include <windows.h>
+#else
+#include <dirent.h>
+#endif
+
+
+typedef struct CrossDirEntry {
+#ifdef _MSC_VER
+    WIN32_FIND_DATA find_data;
+    HANDLE hFind;
+    bool first;
+#else
+    DIR *dir;
+#endif
+} CrossDirEntry;
+
+
+bool cross_open_dir(CrossDirEntry *out, const char *dir_path) {
+#ifdef _MSC_VER
+    char buffer[0x400] = {0};
+    snprintf(buffer, sizeof(buffer), "%s/*", dir_path);
+    out->hFind = FindFirstFile(buffer, &out->find_data);
+    out->first = true;
+    if (out->hFind == INVALID_HANDLE_VALUE) {
+        return false;
+    }
+#else
+    out->dir = opendir(dir_path);
+    if (!out->dir) {
+        return false;
+    }
+#endif
+    return true;
+}
+
+void cross_close_dir(CrossDirEntry *out) {
+#ifdef _MSC_VER
+    FindClose(out->hFind);
+#else
+    closedir(out->dir);
+#endif
+}
+
+const char *cross_next_filename(CrossDirEntry *out) {
+#ifdef _MSC_VER
+    if (!out->first) {
+        if (!FindNextFile(out->hFind, &out->find_data)) {
+            return NULL;
+        }
+    }
+
+    do {
+        const char *filename = out->find_data.cFileName;
+        out->first = false;
+
+        if (strcmp(filename, ".") == 0 || strcmp(filename, "..") == 0) {
+            continue;
+        }
+
+        return filename;
+
+    } while (FindNextFile(out->hFind, &out->find_data));
+#else
+    struct dirent *entry = readdir(out->dir);
+    if (entry) {
+        return entry->d_name;
+    }
+#endif
+    return NULL;
+}
+
 
 typedef Crunch64Error (*compress_bound_fn)(size_t *dst_size, size_t src_len, const uint8_t *const src);
 typedef Crunch64Error (*compress_fn)(size_t *dst_size, uint8_t *dst, size_t src_size, const uint8_t *src);
@@ -21,6 +93,7 @@ const char *const crunch64_error_str[] = {
     [Crunch64Error_ByteConversion] = "Byte conversion",
     [Crunch64Error_OutOfBounds] = "Out of bounds",
     [Crunch64Error_NullPointer] = "Null pointer",
+    [Crunch64Error_InvalidCompressionLevel] = "Invalid compression level",
 };
 
 const char *get_crunch64_error_str(Crunch64Error error) {
@@ -182,9 +255,8 @@ int errors = 0;
 
 void run_tests(const char *name, const char *file_extension, compress_bound_fn compress_bound, compress_fn compress,
                compress_bound_fn decompress_bound, compress_fn decompress) {
-    struct dirent *entry;
-    DIR *dir = opendir("test_data");
-    if (!dir) {
+    CrossDirEntry dir;
+    if (!cross_open_dir(&dir, "test_data")) {
         fprintf(stderr, "Could not open test_data directory\n");
         errors++;
         return;
@@ -194,19 +266,21 @@ void run_tests(const char *name, const char *file_extension, compress_bound_fn c
     fprintf(stderr, "\n");
 
     bool found_tests = false;
-    while ((entry = readdir(dir)) != NULL) {
-        if (!has_suffix(entry->d_name, file_extension)) {
+
+    const char *filename;
+    while ((filename = cross_next_filename(&dir)) != NULL) {
+        if (!has_suffix(filename, file_extension)) {
             continue;
         }
 
         found_tests = true;
 
         char bin_path[512];
-        snprintf(bin_path, sizeof(bin_path), "test_data/%s", entry->d_name);
+        snprintf(bin_path, sizeof(bin_path), "test_data/%s", filename);
         bin_path[strlen(bin_path) - strlen(file_extension)] = '\0'; // remove file extension
 
         char compressed_path[512];
-        snprintf(compressed_path, sizeof(compressed_path), "test_data/%s", entry->d_name);
+        snprintf(compressed_path, sizeof(compressed_path), "test_data/%s", filename);
 
         fprintf(stderr, "Reading file %s\n", bin_path);
         size_t bin_size = 0;
@@ -232,6 +306,8 @@ void run_tests(const char *name, const char *file_extension, compress_bound_fn c
         free(bin);
         free(compressed_data);
     }
+
+    cross_close_dir(&dir);
 
     if (!found_tests) {
         fprintf(stderr, "No test files found for %s\n", name);

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -12,5 +12,5 @@ name = "crunch64"
 path = "src/main.rs"
 
 [dependencies]
-crunch64 = { version = "0.6.1", path = "../lib" }
+crunch64 = { version = "0.6.2", path = "../lib" }
 clap = { version = "4.4.11", features = ["derive"] }

--- a/lib/crunch64/__init__.py
+++ b/lib/crunch64/__init__.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 # Version should be synced with lib/Cargo.toml and lib/pyproject.toml
-__version_info__ = (0, 6, 1)
+__version_info__ = (0, 6, 2)
 __version__ = ".".join(map(str, __version_info__))
 __author__ = "decompals"
 

--- a/lib/pyproject.toml
+++ b/lib/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "crunch64"
 # Version should be synced with lib/Cargo.toml and lib/crunch64/__init__.py
-version = "0.6.1"
+version = "0.6.2"
 description = "A library for handling common compression formats for N64 games"
 requires-python = ">=3.7" # Required by PyO3
 dependencies = [


### PR DESCRIPTION
We now test the built C library in CI to make sure it compiles properly under multiple targets.

musl builds are tested using both gcc and musl targets on the compilation step.

I also added a bunch of ARM targets too into the mix of prebuilt stuff.

---

Changelog:


### Added

- Prebuilt C archive libraries for the following targets:
  - `aarch64-pc-windows-msvc`
  - `aarch64-apple-darwin`
  - `aarch64-unknown-linux-gnu`
  - `aarch64-unknown-linux-musl`
- Most prebuilt C libs are now tested in CI.
  - The following targets are being tested in CI:
    - `x86_64-pc-windows-gnu`
    - `x86_64-pc-windows-msvc`
    - `x86_64-apple-darwin`
    - `aarch64-apple-darwin`
    - `x86_64-unknown-linux-musl`
      - Builds/links using GCC default and Clang with musl target.
    - `x86_64-unknown-linux-gnu`
    - `aarch64-unknown-linux-musl`
    - `aarch64-unknown-linux-gnu`
  - The following targets are NOT being tested in CI:
    - `aarch64-pc-windows-msvc`

### Changed

- Prebuilt C libs are now built under the corresponding native OS instead of
  crosscompiling from an Ubuntu runner.
- Rewrite the C bindings test file to make it compatible with MSVC.
